### PR TITLE
Export `withBoundedScientific`

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -52,6 +52,7 @@ module Data.Aeson.Types.FromJSON
     , withObject
     , withText
     , withArray
+    , withBoundedScientific
     , withScientific
     , withBool
     , withEmbeddedJSON


### PR DESCRIPTION
http://hackage.haskell.org/package/aeson-1.4.0.0/docs/Data-Aeson.html#v:withScientific advises to use `withBoundedScientific` for unbounded types but the function wasn't exported