### PR TITLE
Implement JSON parser using scanner

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -147,7 +147,7 @@ import Prelude.Compat
 
 import Data.Aeson.Types.FromJSON (ifromJSON, parseIndexedJSON)
 import Data.Aeson.Encoding (encodingToLazyByteString)
-import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith, eitherDecodeWith, eitherDecodeStrictWith, jsonEOF, json, jsonEOF', json')
+import Data.Aeson.Scanner.Internal (decodeWith, decodeStrictWith, eitherDecodeWith, eitherDecodeStrictWith, jsonEOF, json, jsonEOF', json')
 import Data.Aeson.Types
 import Data.Aeson.Types.Internal (formatError)
 import qualified Data.ByteString as B

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -29,6 +29,7 @@ module Data.Aeson.Parser.Internal
     , value
     , jstring
     , jstring_
+    , jstringSlow
     , scientific
     -- * Strict parsers
     , json', jsonEOF'

--- a/Data/Aeson/Scanner/Internal.hs
+++ b/Data/Aeson/Scanner/Internal.hs
@@ -1,0 +1,408 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- |
+-- Module:      Data.Aeson.Scanner.Internal
+-- Copyright:   (c) 2011-2016 Bryan O'Sullivan
+--              (c) 2011 MailRank, Inc.
+--              (c) 2020 Yuras Shumovich
+-- License:     BSD3
+-- Maintainer:  Bryan O'Sullivan <bos@serpentine.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- Efficiently and correctly parse a JSON string. The string must be
+-- encoded as UTF-8.
+
+module Data.Aeson.Scanner.Internal
+    (
+    -- * Lazy scanners
+      json, jsonEOF
+    , jsonWith
+    , jsonLast
+    , jsonAccum
+    , jsonNoDup
+    , value
+    , jstring
+    , jstring_
+    , scientific
+    -- * Strict scanners
+    , json', jsonEOF'
+    , jsonWith'
+    , jsonLast'
+    , jsonAccum'
+    , jsonNoDup'
+    , value'
+    -- * Helpers
+    , decodeWith
+    , decodeStrictWith
+    , eitherDecodeWith
+    , eitherDecodeStrictWith
+    -- ** Handling objects with duplicate keys
+    , fromListAccum
+    , parseListNoDup
+    ) where
+
+import Prelude.Compat
+
+import Data.Aeson.Types.Internal
+import qualified Data.Aeson.Parser.Internal as Parser
+import Data.Bits (testBit)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as Lazy (ByteString)
+import Data.Function (fix)
+import Data.Functor.Compat (($>))
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import Data.Word
+import Scanner (Scanner)
+import qualified Scanner
+import qualified Scanner.Attoparsec as Scanner
+
+#define BACKSLASH 92
+#define CLOSE_CURLY 125
+#define CLOSE_SQUARE 93
+#define COMMA 44
+#define DOUBLE_QUOTE 34
+#define OPEN_CURLY 123
+#define OPEN_SQUARE 91
+#define C_0 48
+#define C_9 57
+#define C_A 65
+#define C_F 70
+#define C_a 97
+#define C_f 102
+#define C_n 110
+#define C_t 116
+
+-- | Parse any JSON value.
+--
+-- The conversion of a parsed value to a Haskell value is deferred
+-- until the Haskell value is needed.  This may improve performance if
+-- only a subset of the results of conversions are needed, but at a
+-- cost in thunk allocation.
+--
+-- This function is an alias for 'value'.
+--
+-- ==== Warning
+--
+-- If an object contains duplicate keys, only the first one will be kept.
+-- For a more flexible alternative, see 'jsonWith'.
+json :: Scanner Value
+json = value
+
+-- | Parse any JSON value.
+--
+-- This is a strict version of 'json' which avoids building up thunks
+-- during parsing; it performs all conversions immediately.  Prefer
+-- this version if most of the JSON data needs to be accessed.
+--
+-- This function is an alias for 'value''.
+--
+-- ==== Warning
+--
+-- If an object contains duplicate keys, only the first one will be kept.
+-- For a more flexible alternative, see 'jsonWith''.
+json' :: Scanner Value
+json' = value'
+
+-- Open recursion: object_, object_', array_, array_' are parameterized by the
+-- toplevel Value parser to be called recursively, to keep the parameter
+-- mkObject outside of the recursive loop for proper inlining.
+
+object_ :: ([(Text, Value)] -> Either String Object)
+        -> Scanner Value -> Scanner Value
+object_ mkObject val = {-# SCC "object_" #-} Object
+  <$> objectValues mkObject jstring val
+{-# INLINE object_ #-}
+
+object_' :: ([(Text, Value)] -> Either String Object)
+         -> Scanner Value -> Scanner Value
+object_' mkObject val' = {-# SCC "object_'" #-} do
+  !vals <- objectValues mkObject jstring' val'
+  return (Object vals)
+ where
+  jstring' = do
+    !s <- jstring
+    return s
+{-# INLINE object_' #-}
+
+objectValues :: ([(Text, Value)] -> Either String Object)
+             -> Scanner Text -> Scanner Value -> Scanner (HashMap Text Value)
+objectValues mkObject str val = do
+  skipSpace
+  w <- lookAhead'
+  if w == CLOSE_CURLY
+    then Scanner.anyWord8 $> HashMap.empty
+    else loop []
+ where
+  -- Why use acc pattern here, you may ask? because 'HashMap.fromList' use
+  -- 'unsafeInsert' and it's much faster because it's doing in place update
+  -- to the 'HashMap'!
+  loop acc = do
+    k <- str <* skipSpace <* Scanner.char8 ':'
+    v <- val <* skipSpace
+    ch <- Scanner.satisfy (\w -> w == COMMA || w == CLOSE_CURLY)
+    let acc' = (k, v) : acc
+    if ch == COMMA
+      then skipSpace >> loop acc'
+      else case mkObject acc' of
+        Left err -> fail err
+        Right obj -> pure obj
+{-# INLINE objectValues #-}
+
+array_ :: Scanner Value -> Scanner Value
+array_ val = {-# SCC "array_" #-} Array <$> arrayValues val
+{-# INLINE array_ #-}
+
+array_' :: Scanner Value -> Scanner Value
+array_' val = {-# SCC "array_'" #-} do
+  !vals <- arrayValues val
+  return (Array vals)
+{-# INLINE array_' #-}
+
+arrayValues :: Scanner Value -> Scanner (Vector Value)
+arrayValues val = do
+  skipSpace
+  w <- lookAhead'
+  if w == CLOSE_SQUARE
+    then Scanner.anyWord8 $> Vector.empty
+    else loop [] 1
+  where
+    loop acc !len = do
+      v <- val <* skipSpace
+      ch <- Scanner.satisfy (\w -> w == COMMA || w == CLOSE_SQUARE)
+      if ch == COMMA
+        then skipSpace >> loop (v:acc) (len+1)
+        else return (Vector.reverse (Vector.fromListN len (v:acc)))
+{-# INLINE arrayValues #-}
+
+-- | Parse any JSON value. Synonym of 'json'.
+value :: Scanner Value
+value = jsonWith (pure . HashMap.fromList)
+
+-- | Parse any JSON value.
+--
+-- This parser is parameterized by a function to construct an 'Object'
+-- from a raw list of key-value pairs, where duplicates are preserved.
+-- The pairs appear in __reverse order__ from the source.
+--
+-- ==== __Examples__
+--
+-- 'json' keeps only the first occurence of each key, using 'HashMap.Lazy.fromList'.
+--
+-- @
+-- 'json' = 'jsonWith' ('Right' '.' 'HashMap.fromList')
+-- @
+--
+-- 'jsonLast' keeps the last occurence of each key, using
+-- @'HashMap.Lazy.fromListWith' ('const' 'id')@.
+--
+-- @
+-- 'jsonLast' = 'jsonWith' ('Right' '.' 'HashMap.Lazy.fromListWith' ('const' 'id'))
+-- @
+--
+-- 'jsonAccum' keeps wraps all values in arrays to keep duplicates, using
+-- 'fromListAccum'.
+--
+-- @
+-- 'jsonAccum' = 'jsonWith' ('Right' . 'fromListAccum')
+-- @
+--
+-- 'jsonNoDup' fails if any object contains duplicate keys, using 'parseListNoDup'.
+--
+-- @
+-- 'jsonNoDup' = 'jsonWith' 'parseListNoDup'
+-- @
+jsonWith :: ([(Text, Value)] -> Either String Object) -> Scanner Value
+jsonWith mkObject = fix $ \value_ -> do
+  skipSpace
+  w <- lookAhead'
+  case w of
+    DOUBLE_QUOTE  -> Scanner.anyWord8 *> (String <$> jstring_)
+    OPEN_CURLY    -> Scanner.anyWord8 *> object_ mkObject value_
+    OPEN_SQUARE   -> Scanner.anyWord8 *> array_ value_
+    C_f           -> Scanner.string "false" $> Bool False
+    C_t           -> Scanner.string "true" $> Bool True
+    C_n           -> Scanner.string "null" $> Null
+    _              | w >= 48 && w <= 57 || w == 45
+                  -> Number <$> scientific
+      | otherwise -> fail "not a valid json value"
+{-# INLINE jsonWith #-}
+
+-- | Variant of 'json' which keeps only the last occurence of every key.
+jsonLast :: Scanner Value
+jsonLast = jsonWith (Right . HashMap.fromListWith (const id))
+
+-- | Variant of 'json' wrapping all object mappings in 'Array' to preserve
+-- key-value pairs with the same keys.
+jsonAccum :: Scanner Value
+jsonAccum = jsonWith (Right . fromListAccum)
+
+-- | Variant of 'json' which fails if any object contains duplicate keys.
+jsonNoDup :: Scanner Value
+jsonNoDup = jsonWith parseListNoDup
+
+-- | @'fromListAccum' kvs@ is an object mapping keys to arrays containing all
+-- associated values from the original list @kvs@.
+--
+-- >>> fromListAccum [("apple", Bool True), ("apple", Bool False), ("orange", Bool False)]
+-- fromList [("apple", [Bool False, Bool True]), ("orange", [Bool False])]
+fromListAccum :: [(Text, Value)] -> Object
+fromListAccum =
+  fmap (Array . Vector.fromList . ($ []))
+  . HashMap.fromListWith (.) . (fmap . fmap) (:)
+
+-- | @'fromListNoDup' kvs@ fails if @kvs@ contains duplicate keys.
+parseListNoDup :: [(Text, Value)] -> Either String Object
+parseListNoDup =
+  HashMap.traverseWithKey unwrap . HashMap.fromListWith (\_ _ -> Nothing)
+  . (fmap . fmap) Just
+  where
+    unwrap k Nothing = Left $ "found duplicate key: " ++ show k
+    unwrap _ (Just v) = Right v
+
+-- | Strict version of 'value'. Synonym of 'json''.
+value' :: Scanner Value
+value' = jsonWith' (pure . HashMap.fromList)
+
+-- | Strict version of 'jsonWith'.
+jsonWith' :: ([(Text, Value)] -> Either String Object) -> Scanner Value
+jsonWith' mkObject = fix $ \value_ -> do
+  skipSpace
+  w <- lookAhead'
+  case w of
+    DOUBLE_QUOTE  -> do
+                     !s <- Scanner.anyWord8 *> jstring_
+                     return (String s)
+    OPEN_CURLY    -> Scanner.anyWord8 *> object_' mkObject value_
+    OPEN_SQUARE   -> Scanner.anyWord8 *> array_' value_
+    C_f           -> Scanner.string "false" $> Bool False
+    C_t           -> Scanner.string "true" $> Bool True
+    C_n           -> Scanner.string "null" $> Null
+    _              | w >= 48 && w <= 57 || w == 45
+                  -> do
+                     !n <- scientific
+                     return (Number n)
+      | otherwise -> fail "not a valid json value"
+{-# INLINE jsonWith' #-}
+
+-- | Variant of 'json'' which keeps only the last occurence of every key.
+jsonLast' :: Scanner Value
+jsonLast' = jsonWith' (pure . HashMap.fromListWith (const id))
+
+-- | Variant of 'json'' wrapping all object mappings in 'Array' to preserve
+-- key-value pairs with the same keys.
+jsonAccum' :: Scanner Value
+jsonAccum' = jsonWith' (pure . fromListAccum)
+
+-- | Variant of 'json'' which fails if any object contains duplicate keys.
+jsonNoDup' :: Scanner Value
+jsonNoDup' = jsonWith' parseListNoDup
+
+-- | Parse a quoted JSON string.
+jstring :: Scanner Text
+jstring = Scanner.word8 DOUBLE_QUOTE *> jstring_
+
+-- | Parse a string without a leading quote.
+jstring_ :: Scanner Text
+{-# INLINE jstring_ #-}
+jstring_ = do
+  s <- Scanner.takeWhile $
+    \w -> w /= DOUBLE_QUOTE && w /= BACKSLASH && not (testBit w 7)
+  w <- lookAhead'
+  case w of
+    DOUBLE_QUOTE -> Scanner.anyWord8 $> Text.decodeUtf8 s
+    _ -> Scanner.atto $ Parser.jstringSlow s
+
+decodeWith :: Scanner Value -> (Value -> Result a) -> Lazy.ByteString -> Maybe a
+decodeWith p to s =
+  case Scanner.scanLazy p s of
+    Right v -> case to v of
+                 Success a -> Just a
+                 _         -> Nothing
+    _ -> Nothing
+{-# INLINE decodeWith #-}
+
+decodeStrictWith :: Scanner Value -> (Value -> Result a) -> ByteString
+                 -> Maybe a
+decodeStrictWith p to s =
+  case either Error to (Scanner.scanOnly p s) of
+    Success a -> Just a
+    _         -> Nothing
+{-# INLINE decodeStrictWith #-}
+
+eitherDecodeWith :: Scanner Value -> (Value -> IResult a) -> Lazy.ByteString
+                 -> Either (JSONPath, String) a
+eitherDecodeWith p to s =
+  case Scanner.scanLazy p s of
+    Right v -> case to v of
+                          ISuccess a      -> Right a
+                          IError path msg -> Left (path, msg)
+    Left msg -> Left ([], msg)
+{-# INLINE eitherDecodeWith #-}
+
+eitherDecodeStrictWith :: Scanner Value -> (Value -> IResult a) -> ByteString
+                       -> Either (JSONPath, String) a
+eitherDecodeStrictWith p to s =
+  case either (IError []) to (Scanner.scanOnly p s) of
+    ISuccess a      -> Right a
+    IError path msg -> Left (path, msg)
+{-# INLINE eitherDecodeStrictWith #-}
+
+-- $lazy
+--
+-- The 'json' and 'value' parsers decouple identification from
+-- conversion.  Identification occurs immediately (so that an invalid
+-- JSON document can be rejected as early as possible), but conversion
+-- to a Haskell value is deferred until that value is needed.
+--
+-- This decoupling can be time-efficient if only a smallish subset of
+-- elements in a JSON value need to be inspected, since the cost of
+-- conversion is zero for uninspected elements.  The trade off is an
+-- increase in memory usage, due to allocation of thunks for values
+-- that have not yet been converted.
+
+-- $strict
+--
+-- The 'json'' and 'value'' parsers combine identification with
+-- conversion.  They consume more CPU cycles up front, but have a
+-- smaller memory footprint.
+
+-- | Parse a top-level JSON value followed by optional whitespace and
+-- end-of-input.  See also: 'json'.
+jsonEOF :: Scanner Value
+jsonEOF = json <* skipSpace <* endOfInput
+
+-- | Parse a top-level JSON value followed by optional whitespace and
+-- end-of-input.  See also: 'json''.
+jsonEOF' :: Scanner Value
+jsonEOF' = json' <* skipSpace <* endOfInput
+
+-- | The only valid whitespace in a JSON document is space, newline,
+-- carriage return, and tab.
+skipSpace :: Scanner ()
+skipSpace = Scanner.skipWhile
+  $ \w -> w == 0x20 || w == 0x0a || w == 0x0d || w == 0x09
+{-# INLINE skipSpace #-}
+
+endOfInput :: Scanner ()
+endOfInput = do
+  w <- Scanner.lookAhead
+  case w of
+    Nothing -> return ()
+    Just _ -> fail "input after data"
+
+-- | Parse a JSON number.
+scientific :: Scanner Scientific
+scientific = Scanner.atto Parser.scientific
+
+lookAhead' :: Scanner Word8
+lookAhead' = Scanner.lookAhead
+    >>= maybe (fail "unexpected end of input") return

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -82,6 +82,7 @@ library
     Data.Aeson.Internal
     Data.Aeson.Internal.Time
     Data.Aeson.Parser.Internal
+    Data.Aeson.Scanner.Internal
 
   -- Deprecated modules
   exposed-modules:
@@ -147,6 +148,8 @@ library
   -- Other dependencies
   build-depends:
     attoparsec           >= 0.13.2.2 && < 0.14,
+    scanner              >= 0.3      && < 0.4,
+    scanner-attoparsec   >= 0.1      && < 0.2,
     dlist                >= 0.8.0.4  && < 0.9,
     hashable             >= 1.2.7.0  && < 1.4,
     scientific           >= 0.3.6.2  && < 0.4,

--- a/benchmarks/AesonEncode.hs
+++ b/benchmarks/AesonEncode.hs
@@ -9,7 +9,7 @@ import Prelude.Compat
 import Control.DeepSeq
 import Control.Monad (forM_)
 import Data.Aeson
-import Data.Attoparsec.ByteString (IResult(..), parseWith)
+import Scanner (Result(..), scanWith)
 import Data.Char (isDigit)
 import Data.Time.Clock
 import System.Environment (getArgs)
@@ -27,7 +27,7 @@ main = do
   forM_ args $ \arg -> withFile arg ReadMode $ \h -> do
     putStrLn $ arg ++ ":"
     let refill = B.hGet h 16384
-    result0 <- parseWith refill json =<< refill
+    result0 <- scanWith refill json =<< refill
     r0 <- case result0 of
             Done _ r -> return r
             _        -> fail $ "failed to read " ++ show arg

--- a/benchmarks/AesonParse.hs
+++ b/benchmarks/AesonParse.hs
@@ -8,7 +8,7 @@ import Prelude.Compat
 
 import Data.Aeson
 import Control.Monad
-import Data.Attoparsec.ByteString (IResult(..), parseWith)
+import Scanner (Result(..), scanWith)
 import Data.Time.Clock
 import System.Environment (getArgs)
 import System.IO
@@ -27,7 +27,7 @@ main = do
             | otherwise = do
           hSeek h AbsoluteSeek 0
           let refill = B.hGet h blkSize
-          result <- parseWith refill json =<< refill
+          result <- scanWith refill json =<< refill
           case result of
             Done _ _ -> loop (good+1) bad
             _        -> loop good (bad+1)

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -29,6 +29,8 @@ library
     c-sources:  ../cbits/unescape_string.c
     build-depends:
       attoparsec,
+      scanner,
+      scanner-attoparsec,
       base,
       base-compat,
       containers,
@@ -84,6 +86,7 @@ library
       Data.Aeson.Parser.Unescape
       Data.Aeson.Parser.UnescapeFFI
       Data.Aeson.Parser.UnescapePure
+      Data.Aeson.Scanner.Internal
       Data.Aeson.TH
       Data.Aeson.Text
       Data.Aeson.Types
@@ -248,7 +251,7 @@ executable aeson-benchmark-aeson-encode
   ghc-options: -Wall -O2 -rtsopts
   build-depends:
     aeson-benchmarks,
-    attoparsec,
+    scanner,
     base,
     base-compat,
     bytestring,
@@ -261,7 +264,7 @@ executable aeson-benchmark-aeson-parse
   ghc-options: -Wall -O2 -rtsopts
   build-depends:
     aeson-benchmarks,
-    attoparsec,
+    scanner,
     base,
     base-compat,
     bytestring,

--- a/tests/ErrorMessages.hs
+++ b/tests/ErrorMessages.hs
@@ -11,7 +11,7 @@ import Prelude.Compat
 
 import Data.Aeson (FromJSON(..), Value, json)
 import Data.Aeson.Types (Parser)
-import Data.Aeson.Parser (eitherDecodeWith)
+import Data.Aeson.Scanner.Internal (eitherDecodeWith)
 import Data.Aeson.Internal (formatError, iparse)
 import Data.Algorithm.Diff (PolyDiff (..), getGroupedDiff)
 import Data.Proxy (Proxy(..))


### PR DESCRIPTION
This PR replaces `attoparsec` with non-backtracking parser `scanner`, which improves performance by 20%-40% (see the benchmark results below.) It's WIP yet, I'd like to hear people's opinion on that.

# Issues

There are two main issues with this change:

## Backward compatibility

Since `aeson` exposes `attoparsec` parses from `Data.Aeson.Parser` module, replacing implementation will affect the API.

The possible solution is to convert parser based on `scanner` to one based on `attoparsec` using `toAtto` combinator from [here](https://github.com/Yuras/scanner-attoparsec/commit/f7fff690f2e565d94005c26320bcb742d4efc22b#diff-61024a57a5b895c8501edc2950c22cf7R30). It requires [this PR](https://github.com/bos/attoparsec/pull/165) to be merged though. Note that `toAtto` preserves the speedup, i.e. parser implemented using `scanner` and then converted to `attoparsec` is still faster then one written directly in `attoparsec`.

Alternatively we can expose both implementations for some period of time.

## Error messages

The error messages from the new parser lacks context. Here is a fragment of the output from the `ErrorMessages` test case:

```
        --- Error in $: not enough input. Expecting ':'
        --- Error in $: not enough input. Expecting object value
        --- Error in $: not enough input. Expecting ',' or '}'
        +++ Error in $: No more input
        +++ Error in $: unexpected end of input
        +++ Error in $: No more input
```

The reason is that `scanner` doesn't have a combinator similar to `<?>` from `attoparsec`. It's possible to add it, but it affects performance negatively.

Note that the error messages from `attoparsec` doesn't contain the error location, it makes them less useful. With `scanner` with [can add error location](https://github.com/Yuras/scanner/pull/12) to the error messages, it will make errors more useful.

# Benchmarks

I used the bench-parse.py for benchmarking. Here are the results on my computer. Before:

```
    json-data/twitter1.json :: 60000 times
      0.626 seconds, 95806 parses/sec, 78.120 MB/sec
    json-data/twitter1.json :: 60000 times
      0.599 seconds, 100216 parses/sec, 81.716 MB/sec
    json-data/twitter1.json :: 60000 times
      0.614 seconds, 97689 parses/sec, 79.655 MB/sec
0.8 KB: 100217 msg\/sec (81.7 MB\/sec)
    json-data/twitter10.json :: 13000 times
      0.636 seconds, 20430 parses/sec, 128.477 MB/sec
    json-data/twitter10.json :: 13000 times
      0.624 seconds, 20830 parses/sec, 130.995 MB/sec
    json-data/twitter10.json :: 13000 times
      0.637 seconds, 20412 parses/sec, 128.364 MB/sec
6.4 KB: 20831 msg\/sec (131.0 MB\/sec)
    json-data/twitter20.json :: 7500 times
      0.763 seconds, 9823 parses/sec, 113.058 MB/sec
    json-data/twitter20.json :: 7500 times
      0.742 seconds, 10105 parses/sec, 116.303 MB/sec
    json-data/twitter20.json :: 7500 times
      0.742 seconds, 10103 parses/sec, 116.280 MB/sec
11.8 KB: 10105 msg\/sec (116.3 MB\/sec)
    json-data/twitter50.json :: 2500 times
      0.699 seconds, 3575 parses/sec, 108.937 MB/sec
    json-data/twitter50.json :: 2500 times
      0.703 seconds, 3554 parses/sec, 108.313 MB/sec
    json-data/twitter50.json :: 2500 times
      0.706 seconds, 3540 parses/sec, 107.879 MB/sec
31.2 KB: 3575 msg\/sec (108.9 MB\/sec)
    json-data/twitter100.json :: 1000 times
      0.662 seconds, 1509 parses/sec, 90.703 MB/sec
    json-data/twitter100.json :: 1000 times
      0.679 seconds, 1473 parses/sec, 88.514 MB/sec
    json-data/twitter100.json :: 1000 times
      0.653 seconds, 1530 parses/sec, 91.961 MB/sec
61.5 KB: 1531 msg\/sec (92.0 MB\/sec)
    json-data/jp10.json :: 4000 times
      0.592 seconds, 6756 parses/sec, 96.536 MB/sec
    json-data/jp10.json :: 4000 times
      0.600 seconds, 6661 parses/sec, 95.192 MB/sec
    json-data/jp10.json :: 4000 times
      0.597 seconds, 6702 parses/sec, 95.772 MB/sec
14.6 KB: 6756 msg\/sec (96.5 MB\/sec)
    json-data/jp50.json :: 1200 times
      0.644 seconds, 1862 parses/sec, 80.163 MB/sec
    json-data/jp50.json :: 1200 times
      0.627 seconds, 1914 parses/sec, 82.409 MB/sec
    json-data/jp50.json :: 1200 times
      0.646 seconds, 1858 parses/sec, 80.009 MB/sec
44.1 KB: 1914 msg\/sec (82.4 MB\/sec)
    json-data/jp100.json :: 700 times
      0.743 seconds, 941 parses/sec, 76.231 MB/sec
    json-data/jp100.json :: 700 times
      0.745 seconds, 939 parses/sec, 76.063 MB/sec
    json-data/jp100.json :: 700 times
      0.747 seconds, 937 parses/sec, 75.874 MB/sec
82.9 KB: 942 msg\/sec (76.2 MB\/sec)
```

After:

```
    json-data/twitter1.json :: 60000 times
      0.488 seconds, 122874 parses/sec, 100.190 MB/sec
    json-data/twitter1.json :: 60000 times
      0.480 seconds, 125054 parses/sec, 101.969 MB/sec
    json-data/twitter1.json :: 60000 times
      0.478 seconds, 125445 parses/sec, 102.287 MB/sec
0.8 KB: 125445 msg\/sec (102.3 MB\/sec)
    json-data/twitter10.json :: 13000 times
      0.459 seconds, 28311 parses/sec, 178.035 MB/sec
    json-data/twitter10.json :: 13000 times
      0.466 seconds, 27877 parses/sec, 175.307 MB/sec
    json-data/twitter10.json :: 13000 times
      0.462 seconds, 28159 parses/sec, 177.084 MB/sec
6.4 KB: 28311 msg\/sec (178.0 MB\/sec)
    json-data/twitter20.json :: 7500 times
      0.533 seconds, 14079 parses/sec, 162.038 MB/sec
    json-data/twitter20.json :: 7500 times
      0.527 seconds, 14239 parses/sec, 163.882 MB/sec
    json-data/twitter20.json :: 7500 times
      0.526 seconds, 14248 parses/sec, 163.981 MB/sec
11.8 KB: 14248 msg\/sec (164.0 MB\/sec)
    json-data/twitter50.json :: 2500 times
      0.498 seconds, 5019 parses/sec, 152.932 MB/sec
    json-data/twitter50.json :: 2500 times
      0.492 seconds, 5076 parses/sec, 154.690 MB/sec
    json-data/twitter50.json :: 2500 times
      0.496 seconds, 5035 parses/sec, 153.441 MB/sec
31.2 KB: 5077 msg\/sec (154.7 MB\/sec)
    json-data/twitter100.json :: 1000 times
      0.464 seconds, 2153 parses/sec, 129.369 MB/sec
    json-data/twitter100.json :: 1000 times
      0.463 seconds, 2158 parses/sec, 129.672 MB/sec
    json-data/twitter100.json :: 1000 times
      0.463 seconds, 2158 parses/sec, 129.690 MB/sec
61.5 KB: 2159 msg\/sec (129.7 MB\/sec)
    json-data/jp10.json :: 4000 times
      0.512 seconds, 7811 parses/sec, 111.625 MB/sec
    json-data/jp10.json :: 4000 times
      0.521 seconds, 7677 parses/sec, 109.707 MB/sec
    json-data/jp10.json :: 4000 times
      0.509 seconds, 7855 parses/sec, 112.243 MB/sec
14.6 KB: 7855 msg\/sec (112.2 MB\/sec)
    json-data/jp50.json :: 1200 times
      0.519 seconds, 2313 parses/sec, 99.590 MB/sec
    json-data/jp50.json :: 1200 times
      0.540 seconds, 2222 parses/sec, 95.687 MB/sec
    json-data/jp50.json :: 1200 times
      0.522 seconds, 2299 parses/sec, 98.975 MB/sec
44.1 KB: 2313 msg\/sec (99.6 MB\/sec)
    json-data/jp100.json :: 700 times
      0.623 seconds, 1123 parses/sec, 90.915 MB/sec
    json-data/jp100.json :: 700 times
      0.605 seconds, 1156 parses/sec, 93.613 MB/sec
    json-data/jp100.json :: 700 times
      0.600 seconds, 1166 parses/sec, 94.408 MB/sec
82.9 KB: 1166 msg\/sec (94.4 MB\/sec)
```

