### PR TITLE
Make unit parsing more flexible

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1526,7 +1526,7 @@ instance FromJSON () where
                     then pure ()
                     else prependContext "()" $ fail "expected an empty array or object") j <|>
                 (withObject "()" $ \o ->
-                       if H.empty 0
+                       if H.empty o
                          then pure ()
                          else prependContext "()" $ fail "expected an empty array or object") j
     {-# INLINE parseJSON #-}

--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1526,7 +1526,7 @@ instance FromJSON () where
                     then pure ()
                     else prependContext "()" $ fail "expected an empty array or object") j <|>
                 (withObject "()" $ \o ->
-                       if H.size o == 0
+                       if H.empty 0
                          then pure ()
                          else prependContext "()" $ fail "expected an empty array or object") j
     {-# INLINE parseJSON #-}

--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1521,10 +1521,14 @@ instance FromJSON Ordering where
                   " (expected \"LT\", \"EQ\", or \"GT\")"
 
 instance FromJSON () where
-    parseJSON = withArray "()" $ \v ->
+    parseJSON j = (withArray "()" $ \v ->
                   if V.null v
                     then pure ()
-                    else prependContext "()" $ fail "expected an empty array"
+                    else prependContext "()" $ fail "expected an empty array or object") j <|>
+                (withObject "()" $ \o ->
+                       if H.size o == 0
+                         then pure ()
+                         else prependContext "()" $ fail "expected an empty array or object") j
     {-# INLINE parseJSON #-}
 
 instance FromJSON Char where

--- a/tests/SerializationFormatSpec.hs
+++ b/tests/SerializationFormatSpec.hs
@@ -244,6 +244,7 @@ jsonDecodingExamples = [
   , MaybeExample "Word8 300"  "300"  (Nothing :: Maybe Word8)
   -- Negative zero year, encoding never produces such:
   , MaybeExample "Day -0000-02-03" "\"-0000-02-03\"" (Just (fromGregorian 0 2 3))
+  , Example "()" ["[]", "{}"] () ()
   ]
 
 data Example where


### PR DESCRIPTION
Fix #788 

Current behavior:

```
Prelude Data.Aeson> encode ()
"[]"
Prelude Data.Aeson> decode "[]"
Just ()
Prelude Data.Aeson> decode "{}"
Nothing
```

New behavior:

```
*Data.Aeson> decode "[]" :: Maybe ()
Just ()
*Data.Aeson> decode "{}" :: Maybe ()
Just ()
```

But still:

```
*Data.Aeson> decode "{ \"foo\" : \"bar\" }" :: Maybe ()
Nothing
```