### PR TITLE
toEncoding & JSON keys as strings

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -370,15 +370,15 @@ consToValue target jc opts instTys cons = do
 -- | Map a JSON string to the name of the Haskell variable that
 -- holds that string. Used to gather all necessary JSON keys and
 -- bind them at top-level.
--- By performing this manual floating, we avoid GHC to
--- re-allocate the keys at each call of 'toJSON'/'toEncoding'.
+-- By performing this manual floating, we prevent GHC from
+-- re-allocating the keys at each call of 'toEncoding' (see #804).
 type KeyMap = IORef (H.HashMap String Name)
 
 newKeyMap :: Q KeyMap
 newKeyMap = runIO $ newIORef H.empty
 
--- | Name of the Haskell variable that is going to hold
--- the supplied JSON string.
+-- | Quoted builder for the supplied JSON string, computed using
+-- the variable stored in the 'KeyMap'.
 keyRef :: KeyMap -> String -> Q Exp
 keyRef ref s = do
   vNew <- newName "key"

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -128,8 +128,8 @@ import Data.Aeson.Types.Internal ((<?>), JSONPathElement(Key))
 import Data.Aeson.Types.FromJSON (parseOptionalFieldWith)
 import Data.Aeson.Types.ToJSON (fromPairs, pair)
 import Data.ByteString.Builder as B
-import qualified Data.ByteString.Short as S (pack)
-import qualified Data.ByteString.Lazy as BL (unpack)
+import qualified Data.ByteString.Lazy.Char8 as C (unpack)
+import Data.ByteString.Short (ShortByteString)
 import Control.Monad (liftM2, unless, when)
 import Data.Foldable (foldr')
 import Data.IORef (IORef, atomicModifyIORef, newIORef, readIORef)
@@ -142,6 +142,7 @@ import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import qualified Data.Monoid as Monoid
 import Data.Set (Set)
+import Data.String (IsString (..))
 import Language.Haskell.TH hiding (Arity)
 import Language.Haskell.TH.Datatype
 #if MIN_VERSION_template_haskell(2,8,0) && !(MIN_VERSION_template_haskell(2,10,0))
@@ -362,8 +363,8 @@ consToValue target jc opts instTys cons = do
       labels <- runIO $ readIORef r
       let decs = map
             (\(k,v) ->
-              let str = BL.unpack $ B.toLazyByteString $ EB.string k
-              in valD (varP v) (normalB [| S.pack str |]) [])
+              let str = C.unpack $ B.toLazyByteString $ EB.string k
+              in valD (varP v) (normalB [| fromString str :: ShortByteString |]) [])
             (H.toList labels)
       letE decs $ pure e'
 

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -363,7 +363,7 @@ consToValue target jc opts instTys cons = do
       let decs = map
             (\(k,v) ->
               let str = C.unpack $ B.toLazyByteString $ EB.string k
-              in valD (varP v) (normalB $ [|E.Encoding (B.shortByteString (fromString str))|]) [])
+              in valD (varP v) (normalB [|E.Encoding (B.shortByteString (fromString str))|]) [])
             (H.toList labels)
       letE decs $ pure e'
 


### PR DESCRIPTION
Hello!

My scenario is JSON serialization with `toEncoding` (to `ByteString`) which results in JSON files
with lots of constructor labels (= lots of keys). I am using `deriveToJSON` to derive the `ToJSON` instances.

The current way of implementing `toEncoding` of objects is by supplying key-value pairs, where the key is an Haskell `String`.
Using strings when serializing to `ByteString`s seems inefficient, so I experimented with using `ByteString` for keys instead.
I only touched the Template Haskell part in such a way that, when deriving `toEncoding`, the labels of constructors are escaped at compile time, and also manually lifted at the toplevel of `toEncoding` and thus shared in subsequent calls to `toEncoding` (see dumped splices below).

I benchmarked an artificial example that builds a big binary tree and serializes it with `toEncoding`:

```haskell
data BinTree = TreeLeaf | TreeNode { leftTree :: BinTree, rightTree :: BinTree }
$(deriveToJSON defaultOptions ''BinTree)
```

The performance improvement is promising (it's more than twice as fast):

- Current `aeson`:
```
time                 1.031 s    (1.026 s .. 1.042 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.027 s    (1.026 s .. 1.029 s)
std dev              2.126 ms   (75.05 μs .. 2.567 ms)
variance introduced by outliers: 19% (moderately inflated)
```

```
70,748,400,904 bytes allocated in the heap
    62,214,640 bytes copied during GC
        158,952 bytes maximum residency (8 sample(s))
        54,320 bytes maximum slop
              0 MB total memory in use (0 MB lost due to fragmentation)
```

- This PR:
```
time                 331.7 ms   (329.8 ms .. 335.1 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 330.0 ms   (329.6 ms .. 331.2 ms)
std dev              903.6 μs   (19.72 μs .. 1.248 ms)
variance introduced by outliers: 16% (moderately inflated)
```

```
44,980,570,088 bytes allocated in the heap
    21,969,912 bytes copied during GC
        157,424 bytes maximum residency (6 sample(s))
        52,760 bytes maximum slop
              0 MB total memory in use (0 MB lost due to fragmentation)
```

(The code for this benchmark is here: https://github.com/acondolu/aeson-bintree)

This is the output of `-ddump-splices`:
```haskell
  deriveToJSON defaultOptions ''BinTree
======>
  instance ToJSON BinTree where
    toJSON = [...]
    toEncoding
      = let
          bs_TreeLeaf = pack [...] -- <-- "\"TreeLeaf\""
          bs_TreeNode = [...]
          bs_leftTree = [...]
          bs_rightTree = [...]
          bs_tag = [...]
        in
          \ value_acGC
            -> case value_acGC of
                  TreeLeaf
                    -> fromPairs
                        ((pair' (Encoding (shortByteString bs_tag)))
                            (Encoding (shortByteString bs_TreeLeaf)))
                  TreeNode arg1_acGD arg2_acGE
                    -> fromPairs
                        ((pair' (Encoding (shortByteString bs_tag)))
                            (Encoding (shortByteString bs_TreeNode))
                            <>
                              ((pair' (Encoding (shortByteString bs_leftTree)))
                                (toEncoding arg1_acGD)
                                <>
                                  (pair' (Encoding (shortByteString bs_rightTree)))
                                    (toEncoding arg2_acGE)))
```

Comparison using `aeson` benchmarks:
```
Benchmark                              master  bs-keys         
Examples/decode/github-issues/lazy    2.91e-3  2.78e-3   -4.73%
Examples/decode/github-issues/strict  3.55e-3  2.71e-3  -23.55%
Examples/decode/jp100/lazy            3.63e-3  3.47e-3   -4.43%
Examples/decode/jp100/strict          3.52e-3  3.51e-3   -0.42%
Examples/decode/twitter100/lazy       2.86e-3  2.77e-3   -3.20%
Examples/decode/twitter100/strict     2.58e-3  2.49e-3   -3.33%
zzz-geom-mean                         3.15e-3  2.93e-3   -6.96%
```

### Alternative solution
This PR only improves the performance when deriving instances with TH (unsatisfactory, for instance `genericToEncoding` is left out).

An alternative would be to leave the TH part unchanged, make `pair` to pack the escaped keys to `ByteString`s, and force GHC to do the lifting by itself, by making it realize that escaped keys are constant expressions after all. However, I was not able to do that:
maybe somebody more experienced with the GHC simplifier can help.

Let me know what you think!