### PR TITLE
Integrate issue #678 benchmark into suite

### DIFF
--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -100,12 +100,14 @@ executable aeson-benchmark-suite
   ghc-options:      -Wall -O2 -rtsopts
   build-depends:
       aeson-benchmarks
+    , attoparsec
     , base
     , base-compat-batteries
     , bytestring
     , criterion
     , deepseq
     , filepath
+    , scientific
     , template-haskell
     , text
     , time
@@ -115,6 +117,7 @@ executable aeson-benchmark-suite
     GitHub
     Twitter
     Twitter.Manual
+    Issue673
 
 -- Benchmarks below are haven't been worked out yet
 
@@ -332,20 +335,3 @@ executable aeson-benchmark-foldable
     , text
     , unordered-containers
     , vector
-
-executable aeson-issue-673
-  default-language: Haskell2010
-  main-is:          Issue673.hs
-  hs-source-dirs:   bench
-  ghc-options:      -Wall -O1 -rtsopts
-  build-depends:
-      aeson-benchmarks
-    , attoparsec
-    , base
-    , base-compat-batteries
-    , bytestring
-    , criterion              >=1.0
-    , scientific
-
-  if impl(ghc <8.0)
-    build-depends: semigroups

--- a/benchmarks/bench/Issue673.hs
+++ b/benchmarks/bench/Issue673.hs
@@ -1,24 +1,12 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Main (
-    main,
-    input17,
-    input32,
-    input64,
-    input128,
-    input256,
-    input2048,
-    input4096,
-    input8192,
-    input16384,
-  ) where
+module Issue673 where
 
 import Criterion.Main
 import Prelude.Compat
 import Data.Int (Int64)
 import Data.Scientific (Scientific)
-import Data.Semigroup ((<>))
 import Data.Aeson.Parser (scientific)
 
 import qualified Data.Attoparsec.ByteString.Lazy as AttoL
@@ -87,8 +75,8 @@ input16384 :: LBS.ByteString
 input16384 = generate 16384
 
 
-main :: IO ()
-main =  defaultMain
+benchmark :: Benchmark
+benchmark = bgroup "Integer-decoder"
     -- works on 64bit
     [ benchPair "17" input17
     -- , benchPair "32" input32
@@ -96,20 +84,22 @@ main =  defaultMain
     -- , benchPair "128" input128
     -- , benchPair "256" input256
     , benchPair "2048" input2048
-    , benchPair "4096" input4096
-    , benchPair "8192" input8192
+    -- , benchPair "4096" input4096
+    -- , benchPair "8192" input8192
     , benchPair "16384" input16384
     ]
   where
     benchPair name input = bgroup name
         [ bench "Int"        $ whnf decodeInt input
         , bench "Simple"     $ whnf bsToIntegerSimple (LBS.toStrict input)
-        , bench "Optim"      $ whnf bsToInteger (LBS.toStrict input)
-        , bench "Read"       $ whnf decodeViaRead input
-        , bench "Scientific" $ whnf decodeScientific input
-        , bench "parserA"    $ whnf decodeAtto  input
-        , bench "parserS"    $ whnf decodeAtto8  input
-        , bench "String"     $ whnf decodeString $ "\"" <> input <> "\""
+
+        -- other disabled, they are interesting for comparison only.
+        -- , bench "Optim"      $ whnf bsToInteger (LBS.toStrict input)
+        -- , bench "Read"       $ whnf decodeViaRead input
+        -- , bench "Scientific" $ whnf decodeScientific input
+        -- , bench "parserA"    $ whnf decodeAtto  input
+        -- , bench "parserS"    $ whnf decodeAtto8  input
+        -- , bench "String"     $ whnf decodeString $ "\"" <> input <> "\""
         ]
 
 -------------------------------------------------------------------------------

--- a/benchmarks/bench/Suite.hs
+++ b/benchmarks/bench/Suite.hs
@@ -20,15 +20,15 @@ import qualified Data.Aeson.Encoding.Builder    as Aeson.EB
 import qualified Data.Aeson.Parser.UnescapeFFI  as FFI
 import qualified Data.Aeson.Parser.UnescapePure as Pure
 import qualified Data.ByteString                as BS
+import qualified Data.ByteString.Builder        as B
 import qualified Data.ByteString.Char8          as BS8
 import qualified Data.ByteString.Lazy           as LBS
 import qualified Data.Text                      as T
-import qualified Data.ByteString.Builder as B
-
-import qualified Twitter
-import qualified Twitter.Manual                 ()
 
 import qualified GitHub
+import qualified Issue673
+import qualified Twitter
+import qualified Twitter.Manual                 ()
 
 -------------------------------------------------------------------------------
 -- Decode bench
@@ -104,4 +104,5 @@ main = defaultMain
       ]
     ]
   , escapeBench
+  , Issue673.benchmark
   ]


### PR DESCRIPTION
Results, for interested

```
benchmarking Integer-decoder/17/Int
time                 671.2 ns   (662.0 ns .. 683.7 ns, ci 0.990)
                     0.999 R²   (0.999 R² .. 1.000 R², ci 0.990)
mean                 668.6 ns   (664.5 ns .. 675.0 ns, ci 0.990)
std dev              13.29 ns   (9.056 ns .. 18.60 ns, ci 0.990)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Integer-decoder/17/Simple
time                 411.9 ns   (411.0 ns .. 413.0 ns, ci 0.990)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.990)
mean                 413.3 ns   (411.5 ns .. 415.5 ns, ci 0.990)
std dev              4.795 ns   (3.474 ns .. 6.276 ns, ci 0.990)

benchmarking Integer-decoder/2048/Int
time                 88.97 μs   (88.67 μs .. 89.24 μs, ci 0.990)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.990)
mean                 88.73 μs   (88.51 μs .. 89.05 μs, ci 0.990)
std dev              693.2 ns   (518.8 ns .. 946.9 ns, ci 0.990)

benchmarking Integer-decoder/2048/Simple
time                 215.6 μs   (214.1 μs .. 217.7 μs, ci 0.990)
                     1.000 R²   (0.999 R² .. 1.000 R², ci 0.990)
mean                 215.3 μs   (214.6 μs .. 216.9 μs, ci 0.990)
std dev              2.495 μs   (1.570 μs .. 4.333 μs, ci 0.990)

benchmarking Integer-decoder/16384/Int
time                 921.5 μs   (913.5 μs .. 931.2 μs, ci 0.990)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.990)
mean                 925.0 μs   (921.9 μs .. 928.3 μs, ci 0.990)
std dev              8.438 μs   (5.560 μs .. 12.06 μs, ci 0.990)

benchmarking Integer-decoder/16384/Simple
time                 7.535 ms   (7.384 ms .. 7.690 ms, ci 0.990)
                     0.999 R²   (0.998 R² .. 1.000 R², ci 0.990)
mean                 7.649 ms   (7.584 ms .. 7.776 ms, ci 0.990)
std dev              214.2 μs   (109.1 μs .. 389.7 μs, ci 0.990)
```

I think it's fine to have non-aeson benchmarks too, e.g. `Simple` here. They are good to show the base level, *they shouldn't change when aeson is changed*, so they highlight the noise in results.