### PR TITLE
Fix #837: Stable (in key order) Show Value instance

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,5 +1,5 @@
 name:            aeson
-version:         1.5.5.1
+version:         1.5.6.0
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Web, JSON
@@ -197,7 +197,7 @@ test-suite aeson-tests
     UnitTests.NullaryConstructors
 
   build-depends:
-    QuickCheck >= 2.10.0.1 && < 2.15,
+    QuickCheck >= 2.14.2 && < 2.15,
     aeson,
     integer-logarithms >= 1 && <1.1,
     attoparsec,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 For the latest version of this document, please see [https://github.com/bos/aeson/blob/master/changelog.md](https://github.com/bos/aeson/blob/master/changelog.md).
 
+### 1.5.6.0
+* Make `Show Value` instance print object keys in lexicographic order.
+
 ### 1.5.5.1
 * Fix a bug in `FromJSON QuarterOfYear` instance.
 

--- a/src/Data/Aeson/Parser/Internal.hs
+++ b/src/Data/Aeson/Parser/Internal.hs
@@ -72,6 +72,10 @@ import qualified Data.HashMap.Strict as H
 import qualified Data.Scientific as Sci
 import Data.Aeson.Parser.Unescape (unescapeText)
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Aeson.Types
+
 #define BACKSLASH 92
 #define CLOSE_CURLY 125
 #define CLOSE_SQUARE 93
@@ -260,7 +264,7 @@ jsonNoDup = jsonWith parseListNoDup
 -- associated values from the original list @kvs@.
 --
 -- >>> fromListAccum [("apple", Bool True), ("apple", Bool False), ("orange", Bool False)]
--- fromList [("apple", [Bool False, Bool True]), ("orange", [Bool False])]
+-- fromList [("apple",Array [Bool False,Bool True]),("orange",Array [Bool False])]
 fromListAccum :: [(Text, Value)] -> Object
 fromListAccum =
   fmap (Array . Vector.fromList . ($ [])) . H.fromListWith (.) . (fmap . fmap) (:)

--- a/src/Data/Aeson/TH.hs
+++ b/src/Data/Aeson/TH.hs
@@ -60,8 +60,9 @@ d = Record { testOne = 3.14159
            }
 @
 
->>> fromJSON (toJSON d) == Success d
-> True
+@
+fromJSON (toJSON d) == Success d
+@
 
 This also works for data family instances, but instead of passing in the data
 family name (with double quotes), we pass in a data family instance

--- a/tests/PropUtils.hs
+++ b/tests/PropUtils.hs
@@ -21,6 +21,7 @@ import Encoders
 import Instances ()
 import Test.QuickCheck (Arbitrary(..), Property, Testable, (===), (.&&.), counterexample)
 import Types
+import Text.Read (readMaybe)
 import qualified Data.Attoparsec.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.HashMap.Strict as H
@@ -73,6 +74,9 @@ roundTripNoEnc eq _ i =
 
 roundTripEq :: (Eq a, FromJSON a, ToJSON a, Show a) => a -> a -> Property
 roundTripEq x y = roundTripEnc (===) x y .&&. roundTripNoEnc (===) x y
+
+roundtripReadShow :: Value -> Property
+roundtripReadShow v = readMaybe (show v) === Just v
 
 -- We test keys by encoding HashMap and Map with it
 roundTripKey

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -21,6 +21,7 @@ tests = testGroup "properties" [
       testProperty "encodeDouble" encodeDouble
     , testProperty "encodeInteger" encodeInteger
     ]
+  , testProperty "read . show = id" roundtripReadShow
   , roundTripTests
   , keysTests
   , testGroup "toFromJSON" [

--- a/tests/PropertyRoundTrip.hs
+++ b/tests/PropertyRoundTrip.hs
@@ -37,7 +37,8 @@ import PropertyRTFunctors
 roundTripTests :: TestTree
 roundTripTests =
   testGroup "roundTrip" [
-      testProperty "Bool" $ roundTripEq True
+      testProperty "Value" $ roundTripEq (undefined :: Value)
+    , testProperty "Bool" $ roundTripEq True
     , testProperty "Double" $ roundTripEq (1 :: Approx Double)
     , testProperty "Int" $ roundTripEq (1 :: Int)
     , testProperty "NonEmpty Char" $ roundTripEq (undefined :: NonEmpty Char)


### PR DESCRIPTION
- Add test that read . show roundtrips
- Add test that Value To/FromJSON instances roundtrip (as we got
  Arbitrary Value instance in tests)
- Cleanup some doctest looking comments