### PR TITLE
Fix `object` comments: `earlier` -> `later`

### DIFF
--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -534,7 +534,7 @@ formatRelativePath path = format "" path
 type Pair = (Text, Value)
 
 -- | Create a 'Value' from a list of name\/value 'Pair's.  If duplicate
--- keys arise, earlier keys and their associated values win.
+-- keys arise, later keys and their associated values win.
 object :: [Pair] -> Value
 object = Object . H.fromList
 {-# INLINE object #-}


### PR DESCRIPTION
Unless I'm misunderstanding something, `HashMap.Strict` comments say the opposite about `fromList`.

https://hackage.haskell.org/package/unordered-containers-0.2.13.0/docs/src/Data.HashMap.Internal.html#fromList

```
-- | /O(n)/ Construct a map with the supplied mappings.  If the list
-- contains duplicate mappings, the later mappings take precedence.
fromList :: (Eq k, Hashable k) => [(k, v)] -> HashMap k v
```

A duplicate key later in the list of pairs overrides the earlier one.

Running locally, the following: `A.object ["a" .= (1 :: Int), "b" .= (2 :: Int), "a" .= (3 :: Int)]`
returns: `Object (fromList [("a",Number 3.0),("b",Number 2.0)])`
On the latest versions in hackage: `aeson=1.5.6.0, unordered-containers=0.2.13.0`