### PR TITLE
Migrate to GHC 9.2

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -103,8 +103,8 @@ library
     , bytestring        >=0.10.8.1 && <0.12
     , containers        >=0.5.7.1  && <0.7
     , deepseq           >=1.4.2.0  && <1.5
-    , ghc-prim          >=0.5.0.0  && <0.8
-    , template-haskell  >=2.11.0.0 && <2.18
+    , ghc-prim          >=0.5.0.0  && <0.9
+    , template-haskell  >=2.11.0.0 && <2.19
     , text              >=1.2.3.0  && <1.3
     , time              >=1.6.0.1  && <1.12
 

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -272,6 +272,7 @@ gFooParseJSONRejectUnknownFieldsTagged = genericParseJSON optsRejectUnknownField
 -- Option fields
 --------------------------------------------------------------------------------
 
+#if !MIN_VERSION_base(4,16,0)
 thOptionFieldToJSON :: OptionField -> Value
 thOptionFieldToJSON = $(mkToJSON optsOptionField 'OptionField)
 
@@ -289,6 +290,7 @@ gOptionFieldToEncoding = genericToEncoding optsOptionField
 
 gOptionFieldParseJSON :: Value -> Parser OptionField
 gOptionFieldParseJSON = genericParseJSON optsOptionField
+#endif
 
 thMaybeFieldToJSON :: MaybeField -> Value
 thMaybeFieldToJSON = $(mkToJSON optsOptionField 'MaybeField)

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -156,8 +157,10 @@ instance Arbitrary EitherTextInt where
 instance Arbitrary (GADT String) where
     arbitrary = GADT <$> arbitrary
 
+#if !MIN_VERSION_base(4,16,0)
 instance Arbitrary OptionField where
     arbitrary = OptionField <$> arbitrary
+#endif
 
 
 instance ApproxEq Char where

--- a/tests/PropertyGeneric.hs
+++ b/tests/PropertyGeneric.hs
@@ -5,13 +5,17 @@ module PropertyGeneric ( genericTests ) where
 
 import Prelude.Compat
 
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option(..))
+#endif
 import Encoders
 import Instances ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+#if !MIN_VERSION_base(4,16,0)
 import Test.QuickCheck ( (===) )
 import Types
+#endif
 import PropUtils
 
 
@@ -57,11 +61,13 @@ genericTests =
           , testProperty "Tagged"  (toParseJSON gOneConstructorParseJSONTagged  gOneConstructorToJSONTagged)
           ]
         ]
+#if !MIN_VERSION_base(4,16,0)
       , testGroup "OptionField" [
           testProperty "like Maybe" $
           \x -> gOptionFieldToJSON (OptionField (Option x)) === thMaybeFieldToJSON (MaybeField x)
         , testProperty "roundTrip" (toParseJSON gOptionFieldParseJSON gOptionFieldToJSON)
         ]
+#endif
       ]
     , testGroup "toEncoding" [
         testProperty "NullaryString" $
@@ -110,7 +116,9 @@ genericTests =
       , testProperty "OneConstructorTagged" $
         gOneConstructorToJSONTagged `sameAs` gOneConstructorToEncodingTagged
 
+#if !MIN_VERSION_base(4,16,0)
       , testProperty "OptionField" $
         gOptionFieldToJSON `sameAs` gOptionFieldToEncoding
+#endif
       ]
     ]

--- a/tests/PropertyTH.hs
+++ b/tests/PropertyTH.hs
@@ -1,16 +1,21 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module PropertyTH ( templateHaskellTests ) where
 
 import Prelude.Compat
 
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option(..))
+#endif
 import Encoders
 import Instances ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+#if !MIN_VERSION_base(4,16,0)
 import Test.QuickCheck ( (===) )
 import Types
+#endif
 import PropUtils
 
 
@@ -74,11 +79,13 @@ templateHaskellTests =
           , testProperty "Tagged"  (toParseJSON thOneConstructorParseJSONTagged  thOneConstructorToJSONTagged)
           ]
         ]
+#if !MIN_VERSION_base(4,16,0)
       , testGroup "OptionField" [
           testProperty "like Maybe" $
           \x -> thOptionFieldToJSON (OptionField (Option x)) === thMaybeFieldToJSON (MaybeField x)
         , testProperty "roundTrip" (toParseJSON thOptionFieldParseJSON thOptionFieldToJSON)
         ]
+#endif
       ]
     , testGroup "toEncoding" [
         testProperty "NullaryString" $
@@ -124,7 +131,9 @@ templateHaskellTests =
       , testProperty "OneConstructorTagged" $
         thOneConstructorToJSONTagged `sameAs` thOneConstructorToEncodingTagged
 
+#if !MIN_VERSION_base(4,16,0)
       , testProperty "OptionField" $
         thOptionFieldToJSON `sameAs` thOptionFieldToEncoding
+#endif
       ]
     ]

--- a/tests/SerializationFormatSpec.hs
+++ b/tests/SerializationFormatSpec.hs
@@ -214,8 +214,10 @@ jsonExamples =
   , example "Semigroup.First Int" "2" (pure 2 :: Semigroup.First Int)
   , example "Semigroup.Last Int" "2" (pure 2 :: Semigroup.Last Int)
   , example "Semigroup.WrappedMonoid Int" "2" (Semigroup.WrapMonoid 2 :: Semigroup.WrappedMonoid Int)
+#if !MIN_VERSION_base(4,16,0)
   , example "Semigroup.Option Just" "2" (pure 2 :: Semigroup.Option Int)
   , example "Semigroup.Option Nothing" "null" (Semigroup.Option (Nothing :: Maybe Bool))
+#endif
 
   -- time 1.9
   , example "SystemTime" "123.123456789" (MkSystemTime 123 123456789)

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -18,7 +18,9 @@ import Data.Data
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Identity (Identity (..))
 import Data.Hashable (Hashable (..))
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option)
+#endif
 import Data.Text
 import Data.Time (Day (..), fromGregorian)
 import GHC.Generics
@@ -107,8 +109,10 @@ deriving instance Eq   (GADT a)
 deriving instance Show (GADT a)
 
 newtype MaybeField = MaybeField { maybeField :: Maybe Int }
+#if !MIN_VERSION_base(4,16,0)
 newtype OptionField = OptionField { optionField :: Option Int }
   deriving (Eq, Show)
+#endif
 
 deriving instance Generic Foo
 deriving instance Generic UFoo
@@ -120,7 +124,9 @@ deriving instance Generic (Approx a)
 deriving instance Generic Nullary
 deriving instance Generic (SomeType a)
 deriving instance Generic1 SomeType
+#if !MIN_VERSION_base(4,16,0)
 deriving instance Generic OptionField
+#endif
 deriving instance Generic EitherTextInt
 
 failure :: Show a => String -> String -> a -> Property


### PR DESCRIPTION
This commit allows `aeson` to build and run on GHC 9.2.1, including tests.

Changes:

- Remove tests for `Semigroup.Option` when base >= 4.16.0
- Bump version bounds for `ghc-prim` and `template-haskell`