### PR TITLE
Add haddock example of aesonQQ

### DIFF
--- a/src/Data/Aeson/QQ/Simple.hs
+++ b/src/Data/Aeson/QQ/Simple.hs
@@ -10,6 +10,18 @@ import           Language.Haskell.TH.Syntax (Lift (..))
 import           Prelude                    ()
 import           Prelude.Compat
 
+
+-- | Converts a string representation of a JSON value into 'Data.Aeson.Value' at compile-time.
+--
+-- @
+-- {-\# LANGUAGE QuasiQuotes \#-}
+--
+-- import Data.Aeson (Value)
+-- import Data.Aeson.QQ.Simple
+--
+-- joe :: 'Value'
+-- joe = [aesonQQ|{ "name": \"Joe\", "age": 12 }|]
+-- @
 aesonQQ :: QuasiQuoter
 aesonQQ = QuasiQuoter
     { quoteExp  = aesonExp


### PR DESCRIPTION
Just adding complete example of how this module can be used.

I see 2 problems with haddock of this module: https://hackage.haskell.org/package/aeson-1.5.6.0/docs/Data-Aeson-QQ-Simple.html

1. the link leads to aeson-qq haddocs, which itself points to its README.
Such examples are useles when I'm coding offline with access only to local haddock

2. The difference is not *just* that aeson doesn't support interpolation.
Another difference is that aeson-qq supports [symbol keys](https://github.com/sol/aeson-qq/blob/3b5acf994cb7ee452eb58a4733b21b7eca53132f/src/Data/JSON/QQ.hs#L89)

Example:
```haskell
-- Works with aeson-qq
aesonQqGood = [Data.Aeson.QQ.aesonQQ|{name:"Joe"}|] :: Value

-- Doesn't work with aeson - key not surrounded by quotes
aesonBad = [Data.Aeson.QQ.Simple.aesonQQ|{name:"Joe"}|] :: Value

-- Works in aeson
aesonGood = [Data.Aeson.QQ.Simple.aesonQQ|{"name":"Joe"}|] :: Value
```
For these reasons I think an example directly in the module is needed.

After this PR:

![Screenshot from 2021-07-03 10-00-45](https://user-images.githubusercontent.com/2716069/124347549-917fd600-dbe5-11eb-9382-a6f33720b123.png)


