### PR TITLE
Support text-2.0

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -103,7 +103,7 @@ library
     , deepseq           >=1.4.2.0  && <1.5
     , ghc-prim          >=0.5.0.0  && <0.9
     , template-haskell  >=2.11.0.0 && <2.19
-    , text              >=1.2.3.0  && <1.3
+    , text              >=1.2.3.0  && <1.3 || >=2.0 && <2.1
     , time              >=1.6.0.1  && <1.13
 
   -- Compat
@@ -146,6 +146,7 @@ library
     cpp-options:    -DCFFI
     hs-source-dirs: src-ffi
     other-modules:  Data.Aeson.Parser.UnescapeFFI
+    build-depends:  text < 2.0
 
   if flag(ordered-keymap)
     cpp-options: -DUSE_ORDEREDMAP=1
@@ -153,13 +154,11 @@ library
 test-suite aeson-tests
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests src-ffi src-pure
+  hs-source-dirs:   tests
   main-is:          Tests.hs
-  c-sources:        cbits/unescape_string.c
   ghc-options:      -Wall -threaded -rtsopts
+
   other-modules:
-    Data.Aeson.Parser.UnescapeFFI
-    Data.Aeson.Parser.UnescapePure
     DataFamilies.Encoders
     DataFamilies.Instances
     DataFamilies.Properties

--- a/attoparsec-iso8601/attoparsec-iso8601.cabal
+++ b/attoparsec-iso8601/attoparsec-iso8601.cabal
@@ -40,7 +40,7 @@ library
     base >= 4.9 && < 5,
     base-compat-batteries >= 0.10.0 && < 0.13,
     time-compat >= 1.9.4 && < 1.10,
-    text >= 1.2.3.0 && < 1.3.0.0,
+    text >= 1.2.3.0 && < 1.3.0.0 || >= 2.0 && <2.1,
     time >= 1.6.0.1 && < 1.13
 
   if flag(fast)

--- a/src-pure/Data/Aeson/Parser/UnescapePure.hs
+++ b/src-pure/Data/Aeson/Parser/UnescapePure.hs
@@ -5,6 +5,9 @@
 
 -- The security check at the end (pos > length) only works if pos grows
 -- monotonously, if this condition does not hold, the check is flawed.
+
+{-# LANGUAGE CPP #-}
+
 module Data.Aeson.Parser.UnescapePure
     (
       unescapeText
@@ -13,7 +16,6 @@ module Data.Aeson.Parser.UnescapePure
 import Control.Exception (evaluate, throw, try)
 import Control.Monad (when)
 import Data.ByteString as B
-import Data.Bits (Bits, shiftL, shiftR, (.&.), (.|.))
 import Data.Text (Text)
 import qualified Data.Text.Array as A
 import Data.Text.Encoding.Error (UnicodeException (..))
@@ -21,6 +23,14 @@ import Data.Text.Internal.Private (runText)
 import Data.Text.Unsafe (unsafeDupablePerformIO)
 import Data.Word (Word8, Word16, Word32)
 import GHC.ST (ST)
+
+#if MIN_VERSION_text(2,0,0)
+import Data.Bits (Bits, shiftL, (.&.), (.|.))
+import Data.Text.Internal.Encoding.Utf16 (chr2)
+import Data.Text.Internal.Unsafe.Char (unsafeChr16, unsafeChr32, unsafeWrite)
+#else
+import Data.Bits (Bits, shiftL, shiftR, (.&.), (.|.))
+#endif
 
 -- Different UTF states.
 data Utf =
@@ -144,11 +154,17 @@ unescapeText' bs = runText $ \done -> do
       runUtf dest pos st point c = case decode st point c of
         (UtfGround, 92) -> -- Backslash
             return (pos, StateBackslash)
+#if MIN_VERSION_text(2,0,0)
+        (UtfGround, w) -> do
+            d <- unsafeWrite dest pos (unsafeChr32 w)
+            return (pos + d, StateNone)
+#else
         (UtfGround, w) | w <= 0xffff ->
             writeAndReturn dest pos (fromIntegral w) StateNone
         (UtfGround, w) -> do
             A.unsafeWrite dest pos (0xd7c0 + fromIntegral (w `shiftR` 10))
             writeAndReturn dest (pos + 1) (0xdc00 + fromIntegral (w .&. 0x3ff)) StateNone
+#endif
         (st', p) ->
             return (pos, StateUtf st' p)
 
@@ -200,7 +216,12 @@ unescapeText' bs = runText $ \done -> do
         else if u >= 0xdc00 && u <= 0xdfff then -- Low surrogate.
           throwDecodeError
         else do
+#if MIN_VERSION_text(2,0,0)
+          d <- unsafeWrite dest pos (unsafeChr16 u)
+          return (pos + d, StateNone)
+#else
           writeAndReturn dest pos u StateNone
+#endif
 
       -- Handle surrogates.
       f _ (pos, StateS0 hi) 92 = return (pos, StateS1 hi) -- Backslash
@@ -229,10 +250,19 @@ unescapeText' bs = runText $ \done -> do
         if u < 0xdc00 || u > 0xdfff then
           throwDecodeError
         else do
+#if MIN_VERSION_text(2,0,0)
+          d <- unsafeWrite dest pos (chr2 hi u)
+          return (pos + d, StateNone)
+#else
           A.unsafeWrite dest pos hi
           writeAndReturn dest (pos + 1) u StateNone
+#endif
 
+#if MIN_VERSION_text(2,0,0)
+writeAndReturn :: A.MArray s -> Int -> Word8 -> t -> ST s (Int, t)
+#else
 writeAndReturn :: A.MArray s -> Int -> Word16 -> t -> ST s (Int, t)
+#endif
 writeAndReturn dest pos char res = do
     A.unsafeWrite dest pos char
     return (pos + 1, res)

--- a/src/Data/Aeson/Parser/Internal.hs
+++ b/src/Data/Aeson/Parser/Internal.hs
@@ -342,11 +342,16 @@ jstring_ = do
     Just w | w < 0x20 -> fail "unescaped control character"
     _                 -> jstringSlow s
 
+#if MIN_VERSION_text(2,0,0)
+unsafeDecodeASCII :: B.ByteString -> Text
+unsafeDecodeASCII = TE.decodeASCII
+#else
 -- | The input is assumed to contain only 7bit ASCII characters (i.e. @< 0x80@).
 --   We use TE.decodeLatin1 here because TE.decodeASCII is currently (text-1.2.4.0)
 --   deprecated and equal to TE.decodeUtf8, which is slower than TE.decodeLatin1.
 unsafeDecodeASCII :: B.ByteString -> Text
 unsafeDecodeASCII = TE.decodeLatin1
+#endif
 
 jstringSlow :: B.ByteString -> Parser Text
 {-# INLINE jstringSlow #-}

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -72,12 +72,6 @@ import qualified Data.Vector as Vector
 import qualified ErrorMessages
 import qualified SerializationFormatSpec
 
--- Asserts that we can use both modules at once in the test suite.
-import Data.Aeson.Parser.UnescapeFFI ()
-import Data.Aeson.Parser.UnescapePure ()
-
-
-
 roundTripCamel :: String -> Assertion
 roundTripCamel name = assertEqual "" name (camelFrom '_' $ camelTo '_' name)
 


### PR DESCRIPTION
Closes #893. 

As suggested in `Data.Aeson.Parser.UnescapePure`, CC @eskimor @jprider63.

Tested with 

```cabal
with-compiler: ghc
packages: .
packages: attoparsec-iso8601
packages: examples
tests: true
-- constraints: aeson +cffi

packages: https://hackage.haskell.org/package/text-2.0/candidate/text-2.0.tar.gz

allow-newer:
  quickcheck-instances:text,
  uuid-types:text,
  text-short:text,
  strict:text,
  scientific:text

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec
```