### PR TITLE
Reimplement UnescapePure using staged-streams

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -116,7 +116,7 @@ library
 
   -- Other dependencies
   build-depends:
-      attoparsec            >=0.14.2 && <0.15
+      attoparsec            >=0.14.2   && <0.15
     , data-fix              >=0.3      && <0.4
     , dlist                 >=0.8.0.4  && <1.1
     , hashable              >=1.3.5.0  && <1.5
@@ -198,6 +198,7 @@ test-suite aeson-tests
     , hashable
     , integer-logarithms    >=1        && <1.1
     , OneTuple
+    , primitive
     , QuickCheck            >=2.14.2   && <2.15
     , quickcheck-instances  >=0.3.26.1 && <0.4
     , scientific

--- a/src-pure/Data/Aeson/Parser/UnescapePure.hs
+++ b/src-pure/Data/Aeson/Parser/UnescapePure.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_text(2,0,0)
 -- WARNING: This file is security sensitive as it uses unsafeWrite which does
 -- not check bounds. Any changes should be made with care and we would love to
 -- get informed about them, just cc us in any PR targetting this file: @eskimor @jprider63
@@ -275,3 +277,376 @@ throwDecodeError =
 
 unescapeText :: ByteString -> Either UnicodeException Text
 unescapeText = unsafeDupablePerformIO . try . evaluate . unescapeText'
+
+#else
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf   #-}
+
+module Data.Aeson.Parser.UnescapePure
+  ( unescapeText
+  ) where
+
+import           Control.Exception        (throwIO, try)
+import           Data.Bits                (shiftL, shiftR, (.&.), (.|.))
+import           Data.ByteString          (ByteString)
+import           Data.Text                (Text)
+import           Data.Text.Encoding.Error (UnicodeException (..))
+import           Data.Text.Unsafe         (unsafeDupablePerformIO)
+import           Data.Word                (Word16, Word32, Word8)
+import           Foreign.ForeignPtr       (withForeignPtr)
+import           Foreign.Ptr              (Ptr, plusPtr)
+import           Foreign.Storable         (peek)
+
+import qualified Data.ByteString.Internal as BS
+import qualified Data.Primitive           as P
+import qualified Data.Text.Array          as T
+import qualified Data.Text.Internal       as T
+
+unescapeText :: ByteString -> Either UnicodeException Text
+unescapeText = unsafeDupablePerformIO . try . unescapeTextIO
+
+throwDecodeError :: IO a
+throwDecodeError =
+  let desc = "Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"
+   in throwIO (DecodeError desc Nothing)
+
+-------------------------------------------------------------------------------
+-- unescapeTextIO
+-------------------------------------------------------------------------------
+
+-- This function is generated using staged-streams
+-- See: https://github.com/phadej/staged/blob/master/staged-streams-unicode/src/Unicode/JSON.hs
+--
+-- Because @aeson@ better to not use template-haskell itself,
+-- we dump the splice and prettify it by hand a bit.
+--
+
+unescapeTextIO :: ByteString -> IO Text
+unescapeTextIO bs = case bs of
+  BS.PS fptr off len -> withForeignPtr fptr $ \bsPtr -> do
+    let begin, end :: Ptr Word8
+        begin = plusPtr bsPtr off
+        end   = plusPtr begin len
+
+    arr <- P.newPrimArray len
+
+    let writeLowSurrogate :: Int -> Word16 -> Ptr Word8 -> IO Text
+        writeLowSurrogate !out !w16 !inp = do
+          P.writePrimArray arr out w16
+          state_start (out + 1) inp
+
+        writeCodePoint :: Int -> Ptr Word8 -> Word32 -> IO Text
+        writeCodePoint !out !inp !codepoint
+          | codepoint < 65536 = do
+            P.writePrimArray arr out (fromIntegral codepoint)
+            state_start (out + 1) (plusPtr inp 1)
+
+          | otherwise = do
+            let u = codepoint - 65536
+                hi = fromIntegral (55296 + shiftR u 10) :: Word16
+                lo = fromIntegral (56320 + (u .&. 1023)) :: Word16
+            P.writePrimArray arr out hi
+            writeLowSurrogate (out + 1) lo (plusPtr inp 1)
+
+        state_sudone :: Int -> Ptr Word8 -> Word32 -> Word32 -> IO Text
+        state_sudone !out !inp !hi !lo
+          | 56320 <= lo, lo <= 57343 =
+            writeCodePoint out inp (65536 + (shiftL (hi - 55296) 10 .|. (lo - 56320)))
+
+          | otherwise =
+            throwDecodeError
+
+        state_su4 :: Int -> Ptr Word8 -> Word32 -> Word32 -> IO Text
+        state_su4 !out !inp !hi !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_sudone out inp hi (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_sudone out inp hi (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_sudone out inp hi (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_su3 :: Int -> Ptr Word8 -> Word32 -> Word32 -> IO Text
+        state_su3 !out !inp !hi !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_su4 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_su4 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_su4 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise -> throwDecodeError
+
+        state_su2 :: Int -> Ptr Word8 -> Word32 -> Word32 -> IO Text
+        state_su2 !out !inp !hi !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_su3 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_su3 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_su3 out (plusPtr inp 1) hi (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_su1 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_su1 !out !inp !hi
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_su2 out (plusPtr inp 1) hi (fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_su2 out (plusPtr inp 1) hi (fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_su2 out (plusPtr inp 1) hi (fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        -- high surrogate u
+        state_su :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_su !out !inp !hi
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            case w8 of
+              117 -> state_su1 out (plusPtr inp 1) hi
+              _   -> throwDecodeError
+
+        -- high surrogate slash
+        state_ss :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_ss !out !inp !hi
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            case w8 of
+              92 -> state_su out (plusPtr inp 1) hi
+              _  -> throwDecodeError
+
+        state_udone :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_udone !out !inp !acc
+          | acc < 55296 || acc > 57343 =
+            writeCodePoint out inp acc
+
+          | acc < 56320 =
+            state_ss out (plusPtr inp 1) acc
+
+          | otherwise =
+            throwDecodeError
+
+        state_u4 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_u4 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_udone out inp (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_udone out inp (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_udone out inp (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_u3 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_u3 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_u4 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_u4 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_u4 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_u2 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_u2 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_u3 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_u3 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_u3 out (plusPtr inp 1) (shiftL acc 4 .|. fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_u1 :: Int -> Ptr Word8 -> IO Text
+        state_u1 !out !inp
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | 48 <= w8, w8 <= 57 ->
+                 state_u2 out (plusPtr inp 1) (fromIntegral (w8 - 48))
+               | 65 <= w8, w8 <= 70 ->
+                 state_u2 out (plusPtr inp 1) (fromIntegral (w8 - 55))
+               | 97 <= w8, w8 <= 102 ->
+                 state_u2 out (plusPtr inp 1) (fromIntegral (w8 - 87))
+               | otherwise ->
+                 throwDecodeError
+
+        state_escape :: Int -> Ptr Word8 -> IO Text
+        state_escape out inp
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            case w8 of
+              34 -> do
+                P.writePrimArray arr out 34
+                state_start (out + 1) (plusPtr inp 1)
+
+              92 -> do
+                P.writePrimArray arr out 92
+                state_start (out + 1) (plusPtr inp 1)
+
+              47 -> do
+                P.writePrimArray arr out 47
+                state_start (out + 1) (plusPtr inp 1)
+
+              98 -> do
+                P.writePrimArray arr out 8
+                state_start (out + 1) (plusPtr inp 1)
+
+              102 -> do
+                P.writePrimArray arr out 12
+                state_start (out + 1) (plusPtr inp 1)
+
+              110 -> do
+                P.writePrimArray arr out 10
+                state_start (out + 1) (plusPtr inp 1)
+
+              114 -> do
+                P.writePrimArray arr out 13
+                state_start (out + 1) (plusPtr inp 1)
+
+              116 -> do
+                P.writePrimArray arr out 9
+                state_start (out + 1) (plusPtr inp 1)
+
+              117 ->
+                state_u1 out (plusPtr inp 1)
+
+              _ -> throwDecodeError
+
+        state_input4c :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input4c !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80
+               , let acc' = acc .|.  fromIntegral (w8 .&. 63)
+               , acc' >= 65536 && acc' < 1114112 ->
+                 if {- -- | acc' < 65536 -> do
+                       --   P.writePrimArray arr out (fromIntegral acc' :: Word16)
+                       --   state_start (out + 1) (plusPtr inp 1) -}
+                    | otherwise -> do
+                      let u = acc' - 65536
+                          hi = fromIntegral (55296 + shiftR u 10) :: Word16
+                          lo = fromIntegral (56320 + (u .&. 1023)) :: Word16
+                      P.writePrimArray arr out hi
+                      writeLowSurrogate (out + 1) lo (plusPtr inp 1)
+
+               | otherwise -> throwDecodeError
+
+        state_input4b :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input4b !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80 ->
+                 state_input4c out (plusPtr inp 1) (acc .|. shiftL (fromIntegral (w8 .&. 63)) 6)
+
+               | otherwise -> throwDecodeError
+
+        state_input4 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input4 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80 ->
+                 state_input4b out (plusPtr inp 1) (acc .|. shiftL (fromIntegral (w8 .&. 63)) 12)
+
+               | otherwise -> throwDecodeError
+
+        state_input3b :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input3b !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80
+               , let acc' = acc .|.  fromIntegral (w8 .&. 63)
+               , (acc' >= 2048 && acc' < 55296) || acc' > 57343 ->
+                 if | acc' < 65536 -> do
+                      P.writePrimArray arr out (fromIntegral acc')
+                      state_start (out + 1) (plusPtr inp 1)
+
+                    | otherwise -> do
+                      let u = acc' - 65536
+                          hi = fromIntegral (55296 + shiftR u 10) :: Word16
+                          lo = fromIntegral (56320 + (u .&. 1023)) :: Word16
+                      P.writePrimArray arr out hi
+                      writeLowSurrogate (out + 1) lo (plusPtr inp 1)
+
+               | otherwise -> throwDecodeError
+
+        state_input3 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input3 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80 ->
+                 state_input3b out (plusPtr inp 1) (acc .|. shiftL (fromIntegral (w8 .&. 63)) 6)
+               | otherwise -> throwDecodeError
+
+        state_input2 :: Int -> Ptr Word8 -> Word32 -> IO Text
+        state_input2 !out !inp !acc
+          | inp == end = throwDecodeError
+          | otherwise = do
+            w8 <- peek inp
+            if | (w8 .&. 0xc0) == 0x80
+               , let acc' = acc .|. fromIntegral (w8 .&. 63)
+               , acc' >= 0x80 -> do
+                 P.writePrimArray arr out (fromIntegral acc' :: Word16)
+                 state_start (out + 1) (plusPtr inp 1)
+
+               | otherwise -> throwDecodeError
+
+        state_start :: Int -> Ptr Word8 -> IO Text
+        state_start !out !inp
+          | inp == end = do
+            P.shrinkMutablePrimArray arr out
+            frozenArr <- P.unsafeFreezePrimArray arr
+            return $ case frozenArr of
+              P.PrimArray ba -> T.Text (T.Array ba) 0 out
+
+          | otherwise = do
+            w8 <- peek inp
+            if | w8 == 92 -> state_escape out (plusPtr inp 1)
+               | w8 < 0x80 -> do
+                  P.writePrimArray arr out (fromIntegral w8 :: Word16)
+                  state_start (out + 1) (plusPtr inp 1)
+
+               | w8 < 0xc0 -> throwDecodeError
+               | w8 < 224 -> state_input2 out (plusPtr inp 1) (shiftL (fromIntegral (w8 .&. 63)) 6)
+               | w8 < 240 -> state_input3 out (plusPtr inp 1) (shiftL (fromIntegral (w8 .&. 15)) 12)
+               | w8 < 248 -> state_input4 out (plusPtr inp 1) (shiftL (fromIntegral (w8 .&.  7)) 18)
+               | otherwise -> throwDecodeError
+
+    -- start the state machine
+    state_start (0 :: Int) begin
+
+#endif


### PR DESCRIPTION
See https://github.com/phadej/staged/blob/master/staged-streams-unicode/src/Unicode/JSON.hs
Dumpled splice is manually pasted into aeson,
and then cleaned up.

Results are promising: Haskell implementation is faster then C FFI.

Supporting text-2 would be easy:
staged-streams-unicode can (re)encode into UTF8 too.

```
    benchmarking Escape/ascii/pure
    time                 282.4 ns   (281.4 ns .. 283.2 ns)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 280.3 ns   (279.6 ns .. 281.7 ns)
    std dev              3.188 ns   (1.933 ns .. 5.948 ns)
    
    benchmarking Escape/ascii/ffi
    time                 824.9 ns   (824.0 ns .. 826.2 ns)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 825.5 ns   (824.5 ns .. 827.1 ns)
    std dev              4.052 ns   (2.733 ns .. 5.469 ns)
    
    benchmarking Escape/ascii/text1
    time                 4.213 μs   (4.208 μs .. 4.219 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 4.216 μs   (4.211 μs .. 4.224 μs)
    std dev              21.64 ns   (14.10 ns .. 31.39 ns)
    
    benchmarking Escape/ascii/text2
    time                 4.244 μs   (4.235 μs .. 4.254 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 4.239 μs   (4.231 μs .. 4.252 μs)
    std dev              34.23 ns   (24.20 ns .. 53.40 ns)
    
    benchmarking Escape/cyrillic/pure
    time                 1.008 μs   (1.005 μs .. 1.011 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 1.007 μs   (1.005 μs .. 1.010 μs)
    std dev              6.698 ns   (4.912 ns .. 9.106 ns)
    
    benchmarking Escape/cyrillic/ffi
    time                 2.494 μs   (2.492 μs .. 2.496 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 2.495 μs   (2.493 μs .. 2.498 μs)
    std dev              8.990 ns   (6.583 ns .. 12.84 ns)
    
    benchmarking Escape/cyrillic/text1
    time                 11.91 μs   (11.89 μs .. 11.94 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 11.89 μs   (11.87 μs .. 11.91 μs)
    std dev              65.56 ns   (49.08 ns .. 89.87 ns)
    
    benchmarking Escape/cyrillic/text2
    time                 11.77 μs   (11.76 μs .. 11.79 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 11.78 μs   (11.76 μs .. 11.79 μs)
    std dev              49.32 ns   (38.99 ns .. 62.05 ns)
    
    benchmarking Escape/hexEscapes/pure
    time                 2.967 μs   (2.963 μs .. 2.972 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 2.977 μs   (2.971 μs .. 2.985 μs)
    std dev              23.52 ns   (18.80 ns .. 29.76 ns)
    
    benchmarking Escape/hexEscapes/ffi
    time                 3.843 μs   (3.834 μs .. 3.852 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 3.842 μs   (3.835 μs .. 3.852 μs)
    std dev              27.71 ns   (21.51 ns .. 39.87 ns)
    
    benchmarking Escape/hexEscapes/text1
    time                 33.42 μs   (33.19 μs .. 33.62 μs)
                         1.000 R²   (0.999 R² .. 1.000 R²)
    mean                 33.38 μs   (33.19 μs .. 33.60 μs)
    std dev              720.0 ns   (620.6 ns .. 873.6 ns)
    variance introduced by outliers: 19% (moderately inflated)
    
    benchmarking Escape/hexEscapes/text2
    time                 33.73 μs   (33.56 μs .. 33.96 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 33.67 μs   (33.57 μs .. 33.80 μs)
    std dev              392.5 ns   (311.4 ns .. 512.7 ns)

```