### PR TITLE
Resolve #593: Add charEscapes benchmark

### DIFF
--- a/benchmarks/bench/Suite.hs
+++ b/benchmarks/bench/Suite.hs
@@ -92,6 +92,8 @@ escapeBench = bgroup "Escape"
                 bs = Base16.encode $ TE.encodeUtf16BE $ T.pack [c]
 
         in LBS.toStrict $ B.toLazyByteString $ foldMap formatChar chars
+    , example "charEscapes" $
+        BS.concat $ replicate 10000 $ BS8.pack "\\\""
     ]
   where
     example :: String -> BS.ByteString -> Benchmark


### PR DESCRIPTION
New UnescapePure is on par with FFI implementation

```
benchmarking Escape/charEscapes/pure
time                 37.27 μs   (37.05 μs .. 37.49 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 37.11 μs   (37.00 μs .. 37.28 μs)
std dev              451.2 ns   (252.4 ns .. 760.6 ns)

benchmarking Escape/charEscapes/ffi
time                 36.94 μs   (36.87 μs .. 37.07 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 37.27 μs   (36.98 μs .. 37.98 μs)
std dev              1.469 μs   (445.5 ns .. 2.634 μs)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Escape/charEscapes/text1
time                 229.0 μs   (228.7 μs .. 229.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 228.9 μs   (228.8 μs .. 229.1 μs)
std dev              487.5 ns   (320.3 ns .. 836.1 ns)

benchmarking Escape/charEscapes/text2
time                 272.2 μs   (270.8 μs .. 273.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 271.9 μs   (270.9 μs .. 272.6 μs)
std dev              2.786 μs   (2.211 μs .. 3.532 μs)
```