### PR TITLE
Test with text-2.0 on CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.13.20211226
 #
-# REGENDATA ("0.13.20211116",["github","cabal.project"])
+# REGENDATA ("0.13.20211226",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -233,6 +233,16 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set text-2.0
+        run: |
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.0' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.0' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.0' all
+      - name: constraint set text-1.2
+        run: |
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=1.2.3.0' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=1.2.3.0' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=1.2.3.0' all
       - name: constraint set bytestring-0.11.2.0
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='bytestring >= 0.11.2.0' --dependencies-only -j2 all

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -25,3 +25,13 @@ constraint-set ordered-keymap-off
 
 constraint-set bytestring-0.11.2.0
   constraints: bytestring >= 0.11.2.0
+
+constraint-set text-1.2
+  constraints: text ^>=1.2.3.0
+  tests: True
+  run-tests: True
+
+constraint-set text-2.0
+  constraints: text ^>=2.0
+  tests: True
+  run-tests: True


### PR DESCRIPTION
We have substantial code paths specific for text <2 and >=2,
so we should test both.

Not with benchmarks yet, as we need an aeson release
to build them :)