### PR TITLE
Add explicit toEncoding method to ToJSON QuarterOfYear

### DIFF
--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -1980,6 +1980,8 @@ instance ToJSON QuarterOfYear where
     toJSON Q3 = "q3"
     toJSON Q4 = "q4"
 
+    toEncoding = toEncodingQuarterOfYear
+
 toEncodingQuarterOfYear :: QuarterOfYear -> E.Encoding' a
 toEncodingQuarterOfYear Q1 = E.unsafeToEncoding "\"q1\""
 toEncodingQuarterOfYear Q2 = E.unsafeToEncoding "\"q2\""


### PR DESCRIPTION
It seems to me like this was missed out when adding this instance.
A function was defined to create an `Encoding` but it wasn't used in the instance.

