### PR TITLE
Compare decoding speed with hermes-json

### DIFF
--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -126,7 +126,6 @@ executable aeson-benchmark-suite
     , time
     , unordered-containers
     , vector
-    , hermes-json
 
   other-modules:
     AesonFoldable
@@ -143,7 +142,6 @@ executable aeson-benchmark-suite
     Compare
     Compare.JsonBench
     CompareWithJSON
-    CompareWithHermes
     Dates
     GitHub
     Issue673
@@ -164,6 +162,10 @@ executable aeson-benchmark-suite
   if impl(ghc <8.4)
     other-modules: Compare.JsonBuilder
     build-depends: json-builder
+
+  if impl(ghc >=8.10)
+    other-modules: CompareWithHermes
+    build-depends: hermes-json
 
   if !impl(ghc >=8.0)
     build-depends: fail

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -126,6 +126,7 @@ executable aeson-benchmark-suite
     , time
     , unordered-containers
     , vector
+    , hermes-json
 
   other-modules:
     AesonFoldable
@@ -142,6 +143,7 @@ executable aeson-benchmark-suite
     Compare
     Compare.JsonBench
     CompareWithJSON
+    CompareWithHermes
     Dates
     GitHub
     Issue673

--- a/benchmarks/bench/CompareWithHermes.hs
+++ b/benchmarks/bench/CompareWithHermes.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module CompareWithHermes (benchmark) where
+
+import Prelude.Compat
+
+import Data.Coerce
+import Criterion.Main
+import Data.Maybe (fromMaybe)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Text as A
+import qualified Data.Aeson.Parser.Internal as I
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text.Lazy          as TL
+import qualified Data.Text.Lazy.Builder  as TLB
+import qualified Data.Text.Lazy.Encoding as TLE
+import qualified Data.Hermes as H
+import qualified Twitter as T
+import Twitter.Manual () -- fair comparison with manual Hermes decoders
+
+import Utils
+
+decode :: BL.ByteString -> T.Result
+decode s = fromMaybe (error "fail to parse via Aeson") $ A.decode s
+
+decode' :: BL.ByteString -> T.Result
+decode' s = fromMaybe (error "fail to parse via Aeson") $ A.decode' s
+
+decodeS :: BS.ByteString -> T.Result
+decodeS s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict' s
+
+decodeIP :: BL.ByteString -> T.Result
+decodeIP s = fromMaybe (error "fail to parse via Parser.decodeWith") $
+    I.decodeWith I.jsonEOF A.fromJSON s
+
+decodeH :: BS.ByteString -> T.Result
+decodeH s = case H.decodeEither twitterResultDecoder s of
+  Right result -> result
+  Left err -> error (show err)
+
+twitterResultDecoder :: H.Value -> H.Decoder T.Result
+twitterResultDecoder = H.withObject $ \obj ->
+  T.Result
+    <$> H.atKey "results" (H.list storyDecoder) obj
+    <*> H.atKey "max_id" int64 obj
+    <*> H.atKey "since_id" int64 obj
+    <*> H.atKey "refresh_url" H.text obj
+    <*> H.atKey "next_page" H.text obj
+    <*> H.atKey "results_per_page" H.int obj
+    <*> H.atKey "page" H.int obj
+    <*> H.atKey "completed_in" H.double obj
+    <*> H.atKey "since_id_str" H.text obj
+    <*> H.atKey "max_id_str" H.text obj
+    <*> H.atKey "query" H.text obj
+
+storyDecoder :: H.Value -> H.Decoder T.Story
+storyDecoder = H.withObject $ \obj ->
+  T.Story
+    <$> H.atKey "from_user_id_str" H.text obj
+    <*> H.atKey "profile_image_url" H.text obj
+    <*> H.atKey "created_at" H.text obj
+    <*> H.atKey "from_user" H.text obj
+    <*> H.atKey "id_str" H.text obj
+    <*> H.atKey "metadata" metadataDecoder obj
+    <*> H.atKey "to_user_id" (H.nullable int64) obj
+    <*> H.atKey "text" H.text obj
+    <*> H.atKey "id" int64 obj
+    <*> H.atKey "from_user_id" int64 obj 
+    <*> pure Nothing -- our bench corpus doesn't have any geolocated tweets
+    <*> H.atKey "iso_language_code" H.text obj
+    <*> H.atKey "to_user_id_str" (H.nullable H.text) obj
+    <*> H.atKey "source" H.text obj
+
+int64 = fmap fromIntegral <$> H.int
+
+metadataDecoder :: H.Value -> H.Decoder T.Metadata
+metadataDecoder = H.withObject $ \obj ->
+  T.Metadata <$> H.atKey "result_type" H.text obj
+
+encodeToText :: A.Value -> TL.Text
+encodeToText = TLB.toLazyText . A.encodeToTextBuilder . A.toJSON
+
+encodeViaText :: A.Value -> BL.ByteString
+encodeViaText = TLE.encodeUtf8 . encodeToText
+
+benchmark :: Benchmark
+benchmark =
+  env (readL enFile) $ \enA ->
+  env (readS enFile) $ \enS ->
+  env (readL jpFile) $ \jpA ->
+  env (readS jpFile) $ \jpS ->
+  bgroup "compare-hermes" [
+      bgroup "decode" [
+        bgroup "en" [
+          bench "aeson/lazy"     $ nf decode enA
+        , bench "aeson/strict"   $ nf decode' enA
+        , bench "aeson/stricter" $ nf decodeS enS
+        , bench "aeson/parser"   $ nf decodeIP enA
+        , bench "hermes"         $ nf decodeH enS
+        ]
+      , bgroup "jp" [
+          bench "aeson"          $ nf decode jpA
+        , bench "aeson/stricter" $ nf decodeS jpS
+        , bench "hermes"         $ nf decodeH jpS
+        ]
+      ]
+    ]
+  where
+    enFile = "twitter100.json"
+    jpFile = "jp100.json"

--- a/benchmarks/bench/Suite.hs
+++ b/benchmarks/bench/Suite.hs
@@ -29,6 +29,7 @@ import qualified AesonMap
 import qualified AutoCompare
 import qualified Compare
 import qualified CompareWithJSON
+import qualified CompareWithHermes
 import qualified Dates
 import qualified GitHub
 import qualified Issue673
@@ -130,3 +131,4 @@ main = do
     ]
     ++ Compare.benchmarks -- compares to different libs (encoding)
     ++ [ CompareWithJSON.benchmark ]
+    ++ [ CompareWithHermes.benchmark ]

--- a/benchmarks/bench/Suite.hs
+++ b/benchmarks/bench/Suite.hs
@@ -29,7 +29,9 @@ import qualified AesonMap
 import qualified AutoCompare
 import qualified Compare
 import qualified CompareWithJSON
+#ifdef MIN_VERSION_hermes_json
 import qualified CompareWithHermes
+#endif
 import qualified Dates
 import qualified GitHub
 import qualified Issue673
@@ -131,4 +133,6 @@ main = do
     ]
     ++ Compare.benchmarks -- compares to different libs (encoding)
     ++ [ CompareWithJSON.benchmark ]
+#ifdef MIN_VERSION_hermes_json
     ++ [ CompareWithHermes.benchmark ]
+#endif

--- a/cabal.bench.project
+++ b/cabal.bench.project
@@ -5,3 +5,6 @@ tests: false
 -- This may affect benchmark results
 --package aeson-benchmarks
 --  ghc-options: -O2 -fexpose-all-unfoldings -fspecialise-aggressively
+
+package hermes-json
+  flags: -native_comp


### PR DESCRIPTION
See https://hackage.haskell.org/package/hermes-json-0.1.0.0

```
benchmarking compare-hermes/decode/en/aeson/lazy
time                 1.749 ms   (1.665 ms .. 1.876 ms, ci 0.990)
                     0.992 R²   (0.986 R² .. 1.000 R², ci 0.990)
mean                 1.665 ms   (1.645 ms .. 1.705 ms, ci 0.990)
std dev              69.82 μs   (33.17 μs .. 118.3 μs, ci 0.990)
variance introduced by outliers: 29% (moderately inflated)

benchmarking compare-hermes/decode/en/aeson/strict
time                 1.625 ms   (1.469 ms .. 1.960 ms, ci 0.990)
                     0.941 R²   (0.900 R² .. 0.999 R², ci 0.990)
mean                 1.531 ms   (1.502 ms .. 1.632 ms, ci 0.990)
std dev              149.5 μs   (41.53 μs .. 332.5 μs, ci 0.990)
variance introduced by outliers: 70% (severely inflated)

benchmarking compare-hermes/decode/en/aeson/stricter
time                 1.436 ms   (1.410 ms .. 1.465 ms, ci 0.990)
                     0.998 R²   (0.997 R² .. 0.999 R², ci 0.990)
mean                 1.431 ms   (1.418 ms .. 1.447 ms, ci 0.990)
std dev              39.44 μs   (29.97 μs .. 51.61 μs, ci 0.990)
variance introduced by outliers: 15% (moderately inflated)

benchmarking compare-hermes/decode/en/aeson/parser
time                 2.728 ms   (2.063 ms .. 3.682 ms, ci 0.990)
                     0.807 R²   (0.735 R² .. 0.997 R², ci 0.990)
mean                 2.073 ms   (1.952 ms .. 2.417 ms, ci 0.990)
std dev              527.0 μs   (105.6 μs .. 1.016 ms, ci 0.990)
variance introduced by outliers: 94% (severely inflated)

benchmarking compare-hermes/decode/en/hermes
time                 260.2 μs   (254.0 μs .. 275.1 μs, ci 0.990)
                     0.990 R²   (0.980 R² .. 0.996 R², ci 0.990)
mean                 304.4 μs   (289.4 μs .. 324.0 μs, ci 0.990)
std dev              46.50 μs   (33.56 μs .. 59.77 μs, ci 0.990)
variance introduced by outliers: 90% (severely inflated)

benchmarking compare-hermes/decode/jp/aeson
time                 2.053 ms   (1.892 ms .. 2.392 ms, ci 0.990)
                     0.961 R²   (0.923 R² .. 0.997 R², ci 0.990)
mean                 2.048 ms   (2.000 ms .. 2.168 ms, ci 0.990)
std dev              174.2 μs   (97.08 μs .. 326.8 μs, ci 0.990)
variance introduced by outliers: 62% (severely inflated)

benchmarking compare-hermes/decode/jp/aeson/stricter
time                 1.569 ms   (1.537 ms .. 1.610 ms, ci 0.990)
                     0.995 R²   (0.987 R² .. 0.999 R², ci 0.990)
mean                 1.519 ms   (1.495 ms .. 1.566 ms, ci 0.990)
std dev              80.19 μs   (50.71 μs .. 121.8 μs, ci 0.990)
variance introduced by outliers: 39% (moderately inflated)

benchmarking compare-hermes/decode/jp/hermes
time                 302.0 μs   (288.0 μs .. 324.1 μs, ci 0.990)
                     0.990 R²   (0.980 R² .. 0.999 R², ci 0.990)
mean                 292.0 μs   (287.1 μs .. 303.1 μs, ci 0.990)
std dev              18.04 μs   (10.17 μs .. 31.22 μs, ci 0.990)
variance introduced by outliers: 57% (severely inflated)

```