### PR TITLE
Add documentation for `.:!` for distinguishing between missing and `Null` values

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -811,6 +811,10 @@ ifromJSON = iparse parseJSON
 --
 -- This differs from '.:?' by attempting to parse 'Null' the same as any
 -- other JSON value, instead of interpreting it as 'Nothing'.
+--
+-- This can be useful to distinguish between missing values and 'Null's by
+-- parsing a field into a 'Maybe (Maybe a)', with the outer 'Nothing' being
+-- a missing value and the inner 'Nothing' a 'Null'.
 (.:!) :: (FromJSON a) => Object -> Key -> Parser (Maybe a)
 (.:!) = explicitParseFieldMaybe' parseJSON
 


### PR DESCRIPTION
`.:!` is very helpful for distinguishing between missing and `Null` values, but it's not very obvious how. This PR adds a small piece of documentation found in a [commnet](https://github.com/haskell/aeson/issues/323#issuecomment-178519205) for #323 that might be otherwise lost.