### PR TITLE
Correct `@since` version for `KeyMap.elems`

### DIFF
--- a/src/Data/Aeson/KeyMap.hs
+++ b/src/Data/Aeson/KeyMap.hs
@@ -245,7 +245,7 @@ toList = M.toList . unKeyMap
 
 -- | Return a list of this map' elements.
 --
--- @since 2.0.2.0
+-- @since 2.0.3.0
 elems :: KeyMap v -> [v]
 elems = M.elems . unKeyMap
 
@@ -446,7 +446,7 @@ toList = H.toList . unKeyMap
 
 -- | Return a list of this map' elements.
 --
--- @since 2.0.2.0
+-- @since 2.0.3.0
 elems :: KeyMap v -> [v]
 elems = H.elems . unKeyMap
 


### PR DESCRIPTION
Seems like the wrong version was added in 02702b4bc0a2077a59b99feca00c28fc79072024.