### PR TITLE
Compatibility with Stackage Nightly

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -97,8 +97,8 @@ library
     bytestring       >= 0.10.4.0 && < 0.12,
     containers       >= 0.5.5.1 && < 0.7,
     deepseq          >= 1.3.0.0 && < 1.5,
-    ghc-prim         >= 0.2     && < 0.8,
-    template-haskell >= 2.9.0.0 && < 2.18,
+    ghc-prim         >= 0.2     && < 0.9,
+    template-haskell >= 2.9.0.0 && < 2.19,
     text             >= 1.2.3.0 && < 1.3,
     time             >= 1.4     && < 1.12
 
@@ -132,7 +132,7 @@ library
     attoparsec           >= 0.13.2.2 && < 0.15,
     data-fix             >= 0.3      && < 0.4,
     dlist                >= 0.8.0.4  && < 1.1,
-    hashable             >= 1.2.7.0  && < 1.4,
+    hashable             >= 1.2.7.0  && < 1.5,
     primitive            >= 0.7.0.1  && < 0.8,
     scientific           >= 0.3.7.0  && < 0.4,
     strict               >= 0.4      && < 0.5,

--- a/src/Data/Aeson/Encoding/Builder.hs
+++ b/src/Data/Aeson/Encoding/Builder.hs
@@ -42,7 +42,8 @@ import Prelude.Compat
 
 import Data.Aeson.Internal.Time
 import Data.Aeson.Types.Internal (Value (..))
-import Data.ByteString.Builder as B
+import qualified Data.ByteString.Builder as B
+import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Prim as BP
 import Data.ByteString.Builder.Scientific (scientificBuilder)
 import Data.Char (chr, ord)

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-10-14
+resolver: nightly-2022-03-22
 packages:
 - '.'
 - attoparsec-iso8601
@@ -7,5 +7,3 @@ flags:
     fast: true
   attoparsec-iso8601:
     fast: true
-extra-deps:
-- generic-deriving-1.12.4

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -272,6 +272,7 @@ gFooParseJSONRejectUnknownFieldsTagged = genericParseJSON optsRejectUnknownField
 -- Option fields
 --------------------------------------------------------------------------------
 
+#if !MIN_VERSION_base(4,16,0)
 thOptionFieldToJSON :: OptionField -> Value
 thOptionFieldToJSON = $(mkToJSON optsOptionField 'OptionField)
 
@@ -292,7 +293,7 @@ gOptionFieldParseJSON = genericParseJSON optsOptionField
 
 thMaybeFieldToJSON :: MaybeField -> Value
 thMaybeFieldToJSON = $(mkToJSON optsOptionField 'MaybeField)
-
+#endif
 
 --------------------------------------------------------------------------------
 -- IncoherentInstancesNeeded

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -153,8 +154,10 @@ instance Arbitrary EitherTextInt where
 instance Arbitrary (GADT String) where
     arbitrary = GADT <$> arbitrary
 
+#if !MIN_VERSION_base(4,16,0)
 instance Arbitrary OptionField where
     arbitrary = OptionField <$> arbitrary
+#endif
 
 
 instance ApproxEq Char where

--- a/tests/PropertyGeneric.hs
+++ b/tests/PropertyGeneric.hs
@@ -5,7 +5,9 @@ module PropertyGeneric ( genericTests ) where
 
 import Prelude.Compat
 
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option(..))
+#endif
 import Encoders
 import Instances ()
 import Test.Tasty (TestTree, testGroup)
@@ -57,11 +59,13 @@ genericTests =
           , testProperty "Tagged"  (toParseJSON gOneConstructorParseJSONTagged  gOneConstructorToJSONTagged)
           ]
         ]
+#if !MIN_VERSION_base(4,16,0)
       , testGroup "OptionField" [
           testProperty "like Maybe" $
           \x -> gOptionFieldToJSON (OptionField (Option x)) === thMaybeFieldToJSON (MaybeField x)
         , testProperty "roundTrip" (toParseJSON gOptionFieldParseJSON gOptionFieldToJSON)
         ]
+#endif
       ]
     , testGroup "toEncoding" [
         testProperty "NullaryString" $
@@ -110,7 +114,9 @@ genericTests =
       , testProperty "OneConstructorTagged" $
         gOneConstructorToJSONTagged `sameAs` gOneConstructorToEncodingTagged
 
+#if !MIN_VERSION_base(4,16,0)
       , testProperty "OptionField" $
         gOptionFieldToJSON `sameAs` gOptionFieldToEncoding
+#endif
       ]
     ]

--- a/tests/PropertyTH.hs
+++ b/tests/PropertyTH.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module PropertyTH ( templateHaskellTests ) where
 
 import Prelude.Compat
 
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option(..))
+#endif
 import Encoders
 import Instances ()
 import Test.Tasty (TestTree, testGroup)
@@ -74,11 +77,13 @@ templateHaskellTests =
           , testProperty "Tagged"  (toParseJSON thOneConstructorParseJSONTagged  thOneConstructorToJSONTagged)
           ]
         ]
+#if !MIN_VERSION_base(4,16,0)
       , testGroup "OptionField" [
           testProperty "like Maybe" $
           \x -> thOptionFieldToJSON (OptionField (Option x)) === thMaybeFieldToJSON (MaybeField x)
         , testProperty "roundTrip" (toParseJSON thOptionFieldParseJSON thOptionFieldToJSON)
         ]
+#endif
       ]
     , testGroup "toEncoding" [
         testProperty "NullaryString" $
@@ -124,7 +129,9 @@ templateHaskellTests =
       , testProperty "OneConstructorTagged" $
         thOneConstructorToJSONTagged `sameAs` thOneConstructorToEncodingTagged
 
+#if !MIN_VERSION_base(4,16,0)
       , testProperty "OptionField" $
         thOptionFieldToJSON `sameAs` thOptionFieldToEncoding
+#endif
       ]
     ]

--- a/tests/SerializationFormatSpec.hs
+++ b/tests/SerializationFormatSpec.hs
@@ -212,8 +212,10 @@ jsonExamples =
   , example "Semigroup.First Int" "2" (pure 2 :: Semigroup.First Int)
   , example "Semigroup.Last Int" "2" (pure 2 :: Semigroup.Last Int)
   , example "Semigroup.WrappedMonoid Int" "2" (Semigroup.WrapMonoid 2 :: Semigroup.WrappedMonoid Int)
+#if !MIN_VERSION_base(4,16,0)
   , example "Semigroup.Option Just" "2" (pure 2 :: Semigroup.Option Int)
   , example "Semigroup.Option Nothing" "null" (Semigroup.Option (Nothing :: Maybe Bool))
+#endif
 
   -- time 1.9
   , example "SystemTime" "123.123456789" (MkSystemTime 123 123456789)

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -18,7 +18,9 @@ import Data.Data
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Identity (Identity (..))
 import Data.Hashable (Hashable (..))
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option)
+#endif
 import Data.Text
 import Data.Time (Day (..), fromGregorian)
 import GHC.Generics
@@ -107,8 +109,10 @@ deriving instance Eq   (GADT a)
 deriving instance Show (GADT a)
 
 newtype MaybeField = MaybeField { maybeField :: Maybe Int }
+#if !MIN_VERSION_base(4,16,0)
 newtype OptionField = OptionField { optionField :: Option Int }
   deriving (Eq, Show)
+#endif
 
 deriving instance Generic Foo
 deriving instance Generic UFoo
@@ -120,7 +124,9 @@ deriving instance Generic (Approx a)
 deriving instance Generic Nullary
 deriving instance Generic (SomeType a)
 deriving instance Generic1 SomeType
+#if !MIN_VERSION_base(4,16,0)
 deriving instance Generic OptionField
+#endif
 deriving instance Generic EitherTextInt
 
 failure :: Show a => String -> String -> a -> Property


### PR DESCRIPTION
This makes the Aeson 1.5 series compile with the latest Nightly, which uses GHC 9.2.

One test is failing, as can be seen with

    stack test --stack-yaml stack-nightly.yaml --test-arguments '-p tests.unit.FromJSONKey'

But this test is failing even if base branch is tested on the lts-19 snapshot
(which uses GHC 9.0 and doesn't need these patches). So I think this is a
separate concern. That issue can be seen with these `stack-nightly.yaml` changes:

```diff
diff --git a/stack-nightly.yaml b/stack-nightly.yaml
index fc76b6b..2bc276b 100644
--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-10-14
+resolver: lts-19.0
 packages:
 - '.'
 - attoparsec-iso8601
@@ -7,5 +7,3 @@ flags:
     fast: true
   attoparsec-iso8601:
     fast: true
-extra-deps:
-- generic-deriving-1.12.4
```
