### PR TITLE
Remove SCC pragmas

### DIFF
--- a/src/Data/Aeson/Parser/Internal.hs
+++ b/src/Data/Aeson/Parser/Internal.hs
@@ -133,11 +133,11 @@ json' = value'
 -- mkObject outside of the recursive loop for proper inlining.
 
 object_ :: ([(Key, Value)] -> Either String Object) -> Parser Value -> Parser Value
-object_ mkObject val = {-# SCC "object_" #-} Object <$> objectValues mkObject key val
+object_ mkObject val = Object <$> objectValues mkObject key val
 {-# INLINE object_ #-}
 
 object_' :: ([(Key, Value)] -> Either String Object) -> Parser Value -> Parser Value
-object_' mkObject val' = {-# SCC "object_'" #-} do
+object_' mkObject val' = do
   !vals <- objectValues mkObject key' val'
   return (Object vals)
  where
@@ -172,11 +172,11 @@ objectValues mkObject str val = do
 {-# INLINE objectValues #-}
 
 array_ :: Parser Value -> Parser Value
-array_ val = {-# SCC "array_" #-} Array <$> arrayValues val
+array_ val = Array <$> arrayValues val
 {-# INLINE array_ #-}
 
 array_' :: Parser Value -> Parser Value
-array_' val = {-# SCC "array_'" #-} do
+array_' val = do
   !vals <- arrayValues val
   return (Array vals)
 {-# INLINE array_' #-}
@@ -344,7 +344,7 @@ jstring_ = do
 
 jstringSlow :: B.ByteString -> Parser Text
 {-# INLINE jstringSlow #-}
-jstringSlow s' = {-# SCC "jstringSlow" #-} do
+jstringSlow s' = do
   s <- A.scan startState go <* A.anyWord8
   case unescapeText (B.append s' s) of
     Right r  -> return r

--- a/src/Data/Aeson/Text.hs
+++ b/src/Data/Aeson/Text.hs
@@ -56,18 +56,18 @@ encodeToTextBuilder :: ToJSON a => a -> Builder
 encodeToTextBuilder =
     go . toJSON
   where
-    go Null       = {-# SCC "go/Null" #-} "null"
-    go (Bool b)   = {-# SCC "go/Bool" #-} if b then "true" else "false"
-    go (Number s) = {-# SCC "go/Number" #-} fromScientific s
-    go (String s) = {-# SCC "go/String" #-} string s
+    go Null       = "null"
+    go (Bool b)   = if b then "true" else "false"
+    go (Number s) = fromScientific s
+    go (String s) = string s
     go (Array v)
-        | V.null v = {-# SCC "go/Array" #-} "[]"
-        | otherwise = {-# SCC "go/Array" #-}
+        | V.null v = "[]"
+        | otherwise = 
                       TB.singleton '[' <>
                       go (V.unsafeHead v) <>
                       V.foldr f (TB.singleton ']') (V.unsafeTail v)
       where f a z = TB.singleton ',' <> go a <> z
-    go (Object m) = {-# SCC "go/Object" #-}
+    go (Object m) = 
         case KM.toList m of
           (x:xs) -> TB.singleton '{' <> one x <> foldr f (TB.singleton '}') xs
           _      -> "{}"
@@ -75,12 +75,12 @@ encodeToTextBuilder =
             one (k,v) = string (Key.toText k) <> TB.singleton ':' <> go v
 
 string :: T.Text -> Builder
-string s = {-# SCC "string" #-} TB.singleton '"' <> quote s <> TB.singleton '"'
+string s = TB.singleton '"' <> quote s <> TB.singleton '"'
   where
     quote q = case T.uncons t of
                 Nothing      -> TB.fromText h
                 Just (!c,t') -> TB.fromText h <> escape c <> quote t'
-        where (h,t) = {-# SCC "break" #-} T.break isEscape q
+        where (h,t) = T.break isEscape q
     isEscape c = c == '\"' ||
                  c == '\\' ||
                  c < '\x20'


### PR DESCRIPTION
This patch removes explicit SCC pragmas from aeson.

### Motivation
When profiling an application that uses aeson heavily, profiles become dominated with cost centres from aeson. This can partly be alleviated by passing `-fno-prof-auto`, etc, in aeson's ghc-options. Yet, there are still some explicit SCC pragmas heavily trafficked parts of aeson. These still dominate. 

I think users would benefit from not having these cost centres cluttering their profiles, especially because afaik cost centres can inhibit optimisations, and these SCC pragmas live in functions marked INLINE.