### PR TITLE
fix text-short FromJSON withText typo

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -1697,7 +1697,7 @@ instance FromJSONKey LT.Text where
 
 -- | @since 2.0.2.0
 instance FromJSON ST.ShortText where
-    parseJSON = withText "Lazy Text" $ pure . ST.fromText
+    parseJSON = withText "ShortText" $ pure . ST.fromText
 
 -- | @since 2.0.2.0
 instance FromJSONKey ST.ShortText where


### PR DESCRIPTION
text-short would report `Lazy Text` for a parse failure. This replaces that with `ShortText`.