### PR TITLE
Introduce a flag to default toEncoding to Generic rather than an implementation in terms of toJSON

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -57,6 +57,11 @@ flag ordered-keymap
   default:     True
   manual:      True
 
+flag default-toEncoding-to-toJSON
+  description: Use the toJSON method to give a default value for toEncoding
+  default: False
+  manual: True
+
 library
   default-language: Haskell2010
   hs-source-dirs:   src attoparsec-iso8601/src
@@ -147,6 +152,9 @@ library
 
   if flag(ordered-keymap)
     cpp-options: -DUSE_ORDEREDMAP=1
+
+  if flag(default-toEncoding-to-toJSON)
+    cpp-options: -DDEFAULT_TOENCODING_TO_TOJSON
 
 test-suite aeson-tests
   default-language: Haskell2010

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -313,7 +313,12 @@ class ToJSON a where
     -- @
 
     toEncoding :: a -> Encoding
+#if DEFAULT_TOENCODING_TO_TOJSON
     toEncoding = E.value . toJSON
+#else
+    default toEncoding :: (Generic a, GToJSON' Encoding Zero (Rep a)) => a -> Encoding
+    toEncoding = genericToEncoding defaultOptions
+#endif
 
     toJSONList :: [a] -> Value
     toJSONList = listValue toJSON


### PR DESCRIPTION
This adds a flag (alternative names appreciated) that defines the default toEncoding method of ToJSON in terms of Generics rather than the toJSON method. This introduces symmetry between the toJSON and toEncoding methods, and makes it a lot easier to try to eliminate uses of toJSON from a codebase.

This change is placed behind a flag as it would break code that doesn't use Generic deriving and instead only gives an implementation of toJSON.