### PR TITLE
Expose KeyMap and Key constructors in Internal modules

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -67,7 +67,9 @@ library
     Data.Aeson.Internal
     Data.Aeson.Internal.Time
     Data.Aeson.Key
+    Data.Aeson.Key.Internal
     Data.Aeson.KeyMap
+    Data.Aeson.KeyMap.Internal
     Data.Aeson.Parser
     Data.Aeson.Parser.Internal
     Data.Aeson.QQ.Simple
@@ -81,7 +83,6 @@ library
     Data.Aeson.Internal.Functions
     Data.Aeson.Internal.Text
     Data.Aeson.Internal.TH
-    Data.Aeson.KeyMap.Internal
     Data.Aeson.Parser.Time
     Data.Aeson.Parser.Unescape
     Data.Aeson.Types.Class

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -81,6 +81,7 @@ library
     Data.Aeson.Internal.Functions
     Data.Aeson.Internal.Text
     Data.Aeson.Internal.TH
+    Data.Aeson.KeyMap.Internal
     Data.Aeson.Parser.Time
     Data.Aeson.Parser.Unescape
     Data.Aeson.Types.Class

--- a/src/Data/Aeson/Internal.hs
+++ b/src/Data/Aeson/Internal.hs
@@ -21,10 +21,8 @@ module Data.Aeson.Internal
     , formatError
     , ifromJSON
     , iparse
-    , KeyMap(..)
     ) where
 
 
-import Data.Aeson.KeyMap.Internal
 import Data.Aeson.Types.FromJSON (ifromJSON)
 import Data.Aeson.Types.Internal

--- a/src/Data/Aeson/Internal.hs
+++ b/src/Data/Aeson/Internal.hs
@@ -21,8 +21,10 @@ module Data.Aeson.Internal
     , formatError
     , ifromJSON
     , iparse
+    , KeyMap(..)
     ) where
 
 
-import Data.Aeson.Types.Internal
+import Data.Aeson.KeyMap.Internal
 import Data.Aeson.Types.FromJSON (ifromJSON)
+import Data.Aeson.Types.Internal

--- a/src/Data/Aeson/Key.hs
+++ b/src/Data/Aeson/Key.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Aeson.Key (
     Key,
@@ -14,17 +15,16 @@ module Data.Aeson.Key (
     fromShortText,
 ) where
 
-import Prelude (Eq, Ord, (.), Show (..), String, Maybe (..))
+import Prelude ((.), Show (..), String, Maybe (..))
 
 import Control.Applicative ((<$>))
 import Control.DeepSeq (NFData(..))
-import Data.Data (Data)
+import Data.Aeson.Key.Internal
 import Data.Hashable (Hashable(..))
 import Data.Monoid (Monoid(mempty, mappend))
 import Data.Semigroup (Semigroup((<>)))
 import Data.Text (Text)
 import Data.Type.Coercion (Coercion (..))
-import Data.Typeable (Typeable)
 import Text.Read (Read (..))
 
 import qualified Data.String
@@ -32,9 +32,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Short as ST
 import qualified Language.Haskell.TH.Syntax as TH
 import qualified Test.QuickCheck as QC
-
-newtype Key = Key { unKey :: Text }
-  deriving (Eq, Ord, Typeable, Data)
 
 fromString :: String -> Key
 fromString = Key . T.pack
@@ -53,7 +50,7 @@ toText = unKey
 --
 -- Using 'coercing' we can make more efficient implementations
 -- when 'Key' is backed up by 'Text' without exposing internals.
--- 
+--
 coercionToText :: Maybe (Coercion Key Text)
 coercionToText = Just Coercion
 {-# INLINE coercionToText #-}
@@ -74,7 +71,7 @@ instance Read Key where
     readPrec = fromString <$> readPrec
 
 instance Show Key where
-    showsPrec d (Key k) = showsPrec d k 
+    showsPrec d (Key k) = showsPrec d k
 
 instance Data.String.IsString Key where
     fromString = fromString

--- a/src/Data/Aeson/Key/Internal.hs
+++ b/src/Data/Aeson/Key/Internal.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Data.Aeson.Key.Internal where
+
+import Data.Data (Data)
+import Data.Text (Text)
+import Data.Typeable (Typeable)
+import Prelude (Eq, Ord)
+
+newtype Key = Key { unKey :: Text }
+  deriving (Eq, Ord, Typeable, Data)

--- a/src/Data/Aeson/KeyMap.hs
+++ b/src/Data/Aeson/KeyMap.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- An abstract interface for maps from JSON keys to values.
@@ -88,7 +89,7 @@ module Data.Aeson.KeyMap (
 ) where
 
 -- Import stuff from Prelude explicitly
-import Prelude (Eq(..), Ord((>)), Int, Bool(..), Maybe(..))
+import Prelude (Ord((>)), Int, Bool(..), Maybe(..))
 import Prelude ((.), ($))
 import Prelude (Functor(fmap), Monad(..))
 import Prelude (Show, showsPrec, showParen, shows, showString)
@@ -96,8 +97,8 @@ import Prelude (Show, showsPrec, showParen, shows, showString)
 import Control.Applicative (Applicative)
 import Control.DeepSeq (NFData(..))
 import Data.Aeson.Key (Key)
+import Data.Aeson.KeyMap.Internal
 import Data.Bifunctor (first)
-import Data.Data (Data)
 import Data.Hashable (Hashable(..))
 import Data.HashMap.Strict (HashMap)
 import Data.Map (Map)
@@ -106,7 +107,6 @@ import Data.Semigroup (Semigroup((<>)))
 import Data.Text (Text)
 import Data.These (These (..))
 import Data.Type.Coercion (Coercion (..))
-import Data.Typeable (Typeable)
 import Text.Read (Read (..), Lexeme(..), readListPrecDefault, prec, lexP, parens)
 
 import qualified Data.Aeson.Key as Key
@@ -130,11 +130,6 @@ import qualified Witherable as W
 -------------------------------------------------------------------------------
 -- Map
 -------------------------------------------------------------------------------
-
--- | A map from JSON key type 'Key' to 'v'.
-newtype KeyMap v = KeyMap { unKeyMap :: Map Key v }
-  deriving (Eq, Ord, Typeable, Data, Functor)
-
 
 -- | Construct an empty map.
 empty :: KeyMap v
@@ -343,10 +338,6 @@ mapMaybeWithKey f (KeyMap m) = KeyMap (M.mapMaybeWithKey f m)
 import Data.List (sortBy)
 import Data.Ord (comparing)
 import Prelude (fst)
-
--- | A map from JSON key type 'Key' to 'v'.
-newtype KeyMap v = KeyMap { unKeyMap :: HashMap Key v }
-  deriving (Eq, Ord, Typeable, Data, Functor)
 
 -- | Construct an empty map.
 empty :: KeyMap v

--- a/src/Data/Aeson/KeyMap/Internal.hs
+++ b/src/Data/Aeson/KeyMap/Internal.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor #-}
+
+module Data.Aeson.KeyMap.Internal where
+
+import Data.Aeson.Key (Key)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
+import Prelude (Eq, Ord, Functor)
+
+
+#ifdef USE_ORDEREDMAP
+
+import Data.Map (Map)
+
+-- | A map from JSON key type 'Key' to 'v'.
+newtype KeyMap v = KeyMap { unKeyMap :: Map Key v }
+  deriving (Eq, Ord, Typeable, Data, Functor)
+
+#else
+
+import Data.HashMap.Strict (HashMap)
+
+-- | A map from JSON key type 'Key' to 'v'.
+newtype KeyMap v = KeyMap { unKeyMap :: HashMap Key v }
+  deriving (Eq, Ord, Typeable, Data, Functor)
+
+#endif

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,10 +1,10 @@
-resolver: nightly-2019-10-14
+resolver: lts-19.7
 packages:
 - '.'
 - attoparsec-iso8601
 flags:
   aeson:
-    fast: true
+    ordered-keymap: false
   attoparsec-iso8601:
     fast: true
 extra-deps:


### PR DESCRIPTION
Aeson 2 introduced the opaque `Key` and `KeyMap` types. It's good that they are opaque, but it prevents the user from deriving `newtype` instances for them. Since the wrapped types are simply `HashMap`, `Map`, and `Text`, useful instances for them exist throughout the ecosystem and it would be nice to be able to leverage them.

For example, when working with the `flat` serialization library, I'd like to be able to write

```haskell
{-# LANGUAGE GeneralizedNewtypeDeriving #-}
deriving newtype instance Flat A.Key
deriving newtype instance (Flat a) => Flat (A.KeyMap a)
```

These `deriving` statements only work if the constructors are visible, so this PR exposes them in `Data.Aeson.Key.Internal` and `Data.Aeson.KeyMap.Internal` respectively.