### PR TITLE
Support for datatypes with no constructors in TH and generics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 For the latest version of this document, please see [https://github.com/haskell/aeson/blob/master/changelog.md](https://github.com/haskell/aeson/blob/master/changelog.md).
 
+
+### 2.1.2.0
+
+* Add support for datatypes with no constructors (such as `Void` and `V1`)
+  in `FromJSON` and `ToJSON` provided by generics or `TemplateHaskell` functions
+
 ### 2.1.1.0
 
 - Add `Data.Aeson.KeyMap.!?` (flipped) alias to `Data.Aeson.KeyMap.lookup`.

--- a/src/Data/Aeson/TH.hs
+++ b/src/Data/Aeson/TH.hs
@@ -327,8 +327,8 @@ consToValue :: ToJSONFun
             -- ^ Constructors for which to generate JSON generating code.
             -> Q Exp
 
-consToValue _ _ _ _ [] = error $ "Data.Aeson.TH.consToValue: "
-                             ++ "Not a single constructor given!"
+consToValue _ _ _ _ [] =
+    [| \x -> x `seq` error "case: V1" |]
 
 consToValue target jc opts instTys cons = autoletE liftSBS $ \letInsert -> do
     value <- newName "value"
@@ -688,8 +688,8 @@ consFromJSON :: JSONClass
              -- ^ Constructors for which to generate JSON parsing code.
              -> Q Exp
 
-consFromJSON _ _ _ _ [] = error $ "Data.Aeson.TH.consFromJSON: "
-                                ++ "Not a single constructor given!"
+consFromJSON _ _ _ _ [] =
+    [| \_ -> fail "Attempted to parse empty type" |]
 
 consFromJSON jc tName opts instTys cons = do
   value <- newName "value"
@@ -1154,7 +1154,7 @@ instance {-# OVERLAPPABLE #-} LookupField a where
 
 instance {-# INCOHERENT #-} LookupField (Maybe a) where
     lookupField pj _ _ = parseOptionalFieldWith pj
- 
+
 #if !MIN_VERSION_base(4,16,0)
 instance {-# INCOHERENT #-} LookupField (Semigroup.Option a) where
     lookupField pj tName rec obj key =

--- a/src/Data/Aeson/TH.hs
+++ b/src/Data/Aeson/TH.hs
@@ -1,5 +1,9 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+-- The function `emptyCase` emits the warning, but we should only use it for
+-- Void-like types, where there are no patterns to match on
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -328,7 +332,9 @@ consToValue :: ToJSONFun
             -> Q Exp
 
 consToValue _ _ _ _ [] =
-    [| \x -> x `seq` error "case: V1" |]
+    -- If we put the expression into the TH-generated code directly,
+    -- that makes it require EmptyCase at use-sites too
+    [| emptyCase |]
 
 consToValue target jc opts instTys cons = autoletE liftSBS $ \letInsert -> do
     value <- newName "value"
@@ -2044,3 +2050,6 @@ starKindStatusToName _             = Nothing
 -- the kind variables' Names out.
 catKindVarNames :: [StarKindStatus] -> [Name]
 catKindVarNames = mapMaybe starKindStatusToName
+
+emptyCase :: a -> b
+emptyCase x = case x of {}

--- a/src/Data/Aeson/TH.hs
+++ b/src/Data/Aeson/TH.hs
@@ -1,6 +1,3 @@
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
--- The function `emptyCase` emits the warning, but we should only use it for
--- Void-like types, where there are no patterns to match on
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyCase #-}
@@ -78,6 +75,9 @@ Please note that you can derive instances for tuples using the following syntax:
 -- FromJSON and ToJSON instances for 4-tuples.
 $('deriveJSON' 'defaultOptions' ''(,,,))
 @
+
+If you derive `ToJSON` for a type that has no constructors, the splice will
+require enabling @EmptyCase@ to compile.
 
 -}
 module Data.Aeson.TH
@@ -332,9 +332,7 @@ consToValue :: ToJSONFun
             -> Q Exp
 
 consToValue _ _ _ _ [] =
-    -- If we put the expression into the TH-generated code directly,
-    -- that makes it require EmptyCase at use-sites too
-    [| emptyCase |]
+    [| \x -> case x of {} |]
 
 consToValue target jc opts instTys cons = autoletE liftSBS $ \letInsert -> do
     value <- newName "value"
@@ -2050,6 +2048,3 @@ starKindStatusToName _             = Nothing
 -- the kind variables' Names out.
 catKindVarNames :: [StarKindStatus] -> [Name]
 catKindVarNames = mapMaybe starKindStatusToName
-
-emptyCase :: a -> b
-emptyCase x = case x of {}

--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -978,6 +978,11 @@ class GFromJSON' arity f where
                 -> Value
                 -> Parser (f a)
 
+-- | No constructors.
+instance GFromJSON' arity V1 where
+    gParseJSON' _ _ = fail "Attempted to parse empty type"
+    {-# INLINE gParseJSON' #-}
+
 -- | Single constructor.
 instance ( ConsFromJSON arity a
          , AllNullary         (C1 c a) allNullary

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -832,7 +833,7 @@ instance ( ToJSON1 f
 instance GToJSON' Encoding arity V1 where
     -- Empty values do not exist, which makes the job of formatting them
     -- rather easy:
-    gToJSON _ _ x = x `seq` error "case: V1"
+    gToJSON _ _ x = case x of {}
     {-# INLINE gToJSON #-}
 
 instance ToJSON a => GToJSON' Encoding arity (K1 i a) where

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -829,6 +829,12 @@ instance ( ToJSON1 f
 --------------------------------------------------------------------------------
 -- Generic toEncoding
 
+instance GToJSON' Encoding arity V1 where
+    -- Empty values do not exist, which makes the job of formatting them
+    -- rather easy:
+    gToJSON _ _ x = x `seq` error "case: V1"
+    {-# INLINE gToJSON #-}
+
 instance ToJSON a => GToJSON' Encoding arity (K1 i a) where
     -- Constant values are encoded using their ToJSON instance:
     gToJSON _opts _ = toEncoding . unK1

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -409,6 +409,29 @@ thGADTParseJSONDefault :: Value -> Parser (GADT String)
 thGADTParseJSONDefault = $(mkParseJSON defaultOptions ''GADT)
 
 --------------------------------------------------------------------------------
+-- NoConstructors encoders/decoders
+--------------------------------------------------------------------------------
+
+thNoConstructorsToJSONDefault :: NoConstructors -> Value
+thNoConstructorsToJSONDefault = $(mkToJSON defaultOptions ''NoConstructors)
+
+thNoConstructorsToEncodingDefault :: NoConstructors -> Encoding
+thNoConstructorsToEncodingDefault = $(mkToEncoding defaultOptions ''NoConstructors)
+
+thNoConstructorsParseJSONDefault :: Value -> Parser NoConstructors
+thNoConstructorsParseJSONDefault = $(mkParseJSON defaultOptions ''NoConstructors)
+
+
+gNoConstructorsToJSONDefault :: NoConstructors -> Value
+gNoConstructorsToJSONDefault = genericToJSON defaultOptions
+
+gNoConstructorsToEncodingDefault :: NoConstructors -> Encoding
+gNoConstructorsToEncodingDefault = genericToEncoding defaultOptions
+
+gNoConstructorsParseJSONDefault :: Value -> Parser NoConstructors
+gNoConstructorsParseJSONDefault = genericParseJSON defaultOptions
+
+--------------------------------------------------------------------------------
 -- OneConstructor encoders/decoders
 --------------------------------------------------------------------------------
 

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -46,6 +47,9 @@ data UFoo = UFoo {
       _UFooInt :: Int
     , uFooInt :: Int
     } deriving (Show, Eq, Data, Typeable)
+
+data NoConstructors
+    deriving (Show, Eq, Typeable, Data)
 
 data OneConstructor = OneConstructor
                       deriving (Show, Eq, Typeable, Data)
@@ -116,6 +120,7 @@ newtype OptionField = OptionField { optionField :: Option Int }
 
 deriving instance Generic Foo
 deriving instance Generic UFoo
+deriving instance Generic NoConstructors
 deriving instance Generic OneConstructor
 deriving instance Generic (Product2 a b)
 deriving instance Generic (Product6 a b c d e f)

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -49,7 +48,6 @@ data UFoo = UFoo {
     } deriving (Show, Eq, Data, Typeable)
 
 data NoConstructors
-    deriving (Show, Eq, Typeable, Data)
 
 data OneConstructor = OneConstructor
                       deriving (Show, Eq, Typeable, Data)


### PR DESCRIPTION
This PR adds support for datatypes with no constructors in TH generators (`mkToJSON`, `mkToEncoding` and `mkParseJSON`) and generic instances (`GToJSON'`, `GFromJSON'`).

For example, this PR enables this code:
```hs
data NoConstructors
    deriving (Generic)
instance ToJSON NoConstructors
instance FromJSON NoConstructors

data MyVoid
deriveJSON defaultOptions ''MyVoid
```

On the current `master`, both variants fail: the generics are missing instances of `GToJSON' Encoding Zero V1` and `GFromJSON' Zero V1`, and TH makes an explicit call to `error`.

The actual behavior that is added:

- `toJSON x = seq x (error "case: V1")`
- `toEncoding x = seq x (error "case: V1")`
- `parseJSON _ = fail "Attempted to parse empty type"`

The main use case is to allow substituting such types into polymorphic sums, where some variants are not used for a particular instantiation, and we need to serialize/deserialize the sum; though, I think it's a natural generalization by itself. As an example of such use case:
```hs
class
    ( ToJSON (ResultType lang)
    , ToJSON (FailureType lang)
    , FromJSON (ResultType lang)
    , FromJSON (FailureType lang)
    ) =>
    RecordableResult (lang :: k)
  where
    data ResultType lang
    data FailureType lang

data RequestOutcome lang
    = OutcomeSuccess (ResultType lang)
    | OutcomeFailure (FailureType lang)
    deriving (Generic)
instance (RecordableResult lang) => ToJSON (RequestOutcome lang)
instance (RecordableResult lang) => FromJSON (RequestOutcome lang)

instance RecordableResult MonadDatabase where
    data ResultType MonadDatabase = DatabaseResult Aeson.Value
        deriving (Generic, ToJSON, FromJSON)
    data FailureType MonadDatabase = DatabaseError DatabaseException
        deriving (Generic, ToJSON, FromJSON)

instance (ToJSON r, FromJSON r) => RecordableResult (MonadReader r) where
    data ResultType (MonadReader r) = ReaderResult r
        deriving (Generic, ToJSON, FromJSON)
    data FailureType (MonadReader r) -- MonadReader never fails
        deriving (Generic, ToJSON, FromJSON)
        -- but we still need ToJSON/FromJSON for the surrounding machinery to work
```