### PR TITLE
Add Generically instances

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -107,6 +107,7 @@ library
   -- Compat
   build-depends:
       base-compat-batteries  >=0.10.0 && <0.13
+    , generically            >=0.1    && <0.2
     , time-compat            >=1.9.6  && <1.10
 
   if !impl(ghc >=8.6)
@@ -194,6 +195,7 @@ test-suite aeson-tests
     , dlist
     , filepath
     , generic-deriving      >=1.10     && <1.15
+    , generically
     , ghc-prim              >=0.2
     , hashable
     , indexed-traversable

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -31,6 +31,7 @@ library
     , data-fix
     , deepseq
     , dlist
+    , generically
     , ghc-prim
     , hashable
     , indexed-traversable

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ For the latest version of this document, please see [https://github.com/haskell/
 - Export `mapWithKey` from `Data.Aeson.KeyMap` module.
 - Export `ifromJSON` and `iparse` from `Data.Aeson.Types`. Add `iparseEither`.
 - Add `MonadFix Parser` instance.
+- Make `Semigroup Series` slightly lazier
+- Add instances for `Generically` type
 
 ### 2.0.3.0
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -9,6 +9,11 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecursiveDo #-}
 
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
+
 -- For Data.Aeson.Types.camelTo
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
@@ -55,6 +60,7 @@ import Data.Text (Text)
 import Data.Time (UTCTime)
 import Data.Time.Format.Compat (parseTimeM, defaultTimeLocale)
 import GHC.Generics (Generic)
+import GHC.Generics.Generically (Generically (..))
 import Instances ()
 import Numeric.Natural (Natural)
 import System.Directory (getDirectoryContents)
@@ -97,9 +103,13 @@ data Wibble = Wibble {
 
 instance FromJSON Wibble
 
+#if __GLASGOW_HASKELL__ >= 806
+deriving via Generically Wibble instance ToJSON Wibble
+#else
 instance ToJSON Wibble where
     toJSON     = genericToJSON defaultOptions
     toEncoding = genericToEncoding defaultOptions
+#endif
 
 -- Test that if we put a bomb in a data structure, but only demand
 -- part of it via lazy encoding, we do not unexpectedly fail.


### PR DESCRIPTION
This allows to "properly" derive ToJSON instances.

The `generically` package is not yet released, so this is PoC (benchmarks will fail, as I didn't update their project file yet)