### PR TITLE
Improve `Arbitrary` instance.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 For the latest version of this document, please see [https://github.com/haskell/aeson/blob/master/changelog.md](https://github.com/haskell/aeson/blob/master/changelog.md).
 
+### Upcoming
+
+* Improve `Arbitrary` instance (see #980, requires major version bump).
+
 ### 2.1.2.0
 
 * Support deriving for empty datatypes (such as `Void` and `V1`)

--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -453,11 +453,13 @@ type RepValue
 
 arbValue :: Int -> QC.Gen Value
 arbValue n
-    | n <= 0 = QC.oneof
+    | n <= 1 = QC.oneof
         [ pure Null
         , Bool <$> QC.arbitrary
         , String <$> arbText
         , Number <$> arbScientific
+        , pure emptyObject
+        , pure emptyArray
         ]
 
     | otherwise = QC.oneof


### PR DESCRIPTION
Fixes #980. As discussed there, simply changing `n <= 0` to `n <= 1`
gives good generation of strings, bools, numbers and null. Turns out
it also forbids `[]` and `{}` from being generated, so I added those
explicitly to that case.

My understanding is this requires a major version bump, as a change in
behavior of an exported function.
