### PR TITLE
Allow base-compat-0.13 in attoparsec-iso8601

### DIFF
--- a/attoparsec-iso8601/attoparsec-iso8601.cabal
+++ b/attoparsec-iso8601/attoparsec-iso8601.cabal
@@ -1,5 +1,6 @@
 name:            attoparsec-iso8601
 version:         1.1.0.0
+x-revision:      1
 synopsis:        Parsing of ISO 8601 dates, originally from aeson
 description:     Parsing of ISO 8601 dates, originally from aeson.
 license:         BSD3
@@ -29,7 +30,7 @@ library
   build-depends:
     attoparsec >= 0.14.2 && < 0.15,
     base >= 4.9 && < 5,
-    base-compat-batteries >= 0.10.0 && < 0.13,
+    base-compat-batteries >= 0.10.0 && < 0.14,
     time-compat >= 1.9.4 && < 1.10,
     text >= 1.2.3.0 && < 1.3.0.0 || >= 2.0 && <2.1,
     time >= 1.6.0.1 && < 1.13


### PR DESCRIPTION
Closes #1018 