### PR TITLE
docs: use ssh protocol to clone

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Please report bugs via the
 
 Master [git repository](http://github.com/haskell/aeson):
 
-* `git clone git://github.com/haskell/aeson.git`
+* `git clone git@github.com:haskell/aeson.git`
 
 See what's changed in recent (and upcoming) releases:
 


### PR DESCRIPTION
When using the git protocol to pull the repo, it requires additional setup work. The repo only has `40.43 MiB` when cloning, we could use `ssh` to clone it directly I believe.

Regards