### PR TITLE
Type-directed optional fields

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -168,6 +168,10 @@ test-suite aeson-tests
     Types
     UnitTests
     UnitTests.NullaryConstructors
+    UnitTests.OptionalFields
+    UnitTests.OptionalFields.Common
+    UnitTests.OptionalFields.Generics
+    UnitTests.OptionalFields.TH
 
   build-depends:
       aeson

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -296,29 +296,6 @@ gOptionFieldParseJSON = genericParseJSON optsOptionField
 thMaybeFieldToJSON :: MaybeField -> Value
 thMaybeFieldToJSON = $(mkToJSON optsOptionField 'MaybeField)
 
-
---------------------------------------------------------------------------------
--- IncoherentInstancesNeeded
---------------------------------------------------------------------------------
-
--- | This test demonstrates the need for IncoherentInstances. See the definition
--- of 'IncoherentInstancesNeeded' for a discussion of the issue.
---
--- NOTE 1: We only need to compile this test. We do not need to run it.
---
--- NOTE 2: We actually only use the INCOHERENT pragma on specific instances
--- instead of the IncoherentInstances language extension. Therefore, this is
--- only supported on GHC versions >= 7.10.
-incoherentInstancesNeededParseJSONString :: FromJSON a => Value -> Parser (IncoherentInstancesNeeded a)
-incoherentInstancesNeededParseJSONString = case () of
-  _ | True  -> $(mkParseJSON defaultOptions ''IncoherentInstancesNeeded)
-    | False -> genericParseJSON defaultOptions
-
-incoherentInstancesNeededToJSON :: ToJSON a => IncoherentInstancesNeeded a -> Value
-incoherentInstancesNeededToJSON = case () of
-  _ | True  -> $(mkToJSON defaultOptions ''IncoherentInstancesNeeded)
-    | False -> genericToJSON defaultOptions
-
 -------------------------------------------------------------------------------
 -- EitherTextInt encoders/decodes
 -------------------------------------------------------------------------------

--- a/tests/PropertyTH.hs
+++ b/tests/PropertyTH.hs
@@ -130,10 +130,5 @@ templateHaskellTests =
         thOneConstructorToJSONDefault `sameAs` thOneConstructorToEncodingDefault
       , testProperty "OneConstructorTagged" $
         thOneConstructorToJSONTagged `sameAs` thOneConstructorToEncodingTagged
-
-#if !MIN_VERSION_base(4,16,0)
-      , testProperty "OptionField" $
-        thOptionFieldToJSON `sameAs` thOptionFieldToEncoding
-#endif
       ]
     ]

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -82,18 +82,6 @@ data SomeType a = Nullary
                 | List [a]
   deriving (Eq, Show)
 
--- | This type requires IncoherentInstances for the instances of the type
--- classes Data.Aeson.TH.LookupField and Data.Aeson.Types.FromJSON.FromRecord.
---
--- The minimum known requirements for this type are:
--- * Record type with at least two fields
--- * One field type is either a type parameter or a type/data family
--- * Another field type is a @Maybe@ of the above field type
-data IncoherentInstancesNeeded a = IncoherentInstancesNeeded
-  { incoherentInstancesNeededMaybeNot :: a
-  , incoherentInstancesNeededMaybeYes :: Maybe a
-  } deriving Generic
-
 -- Used for testing UntaggedValue SumEncoding
 data EitherTextInt
     = LeftBool Bool

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -60,6 +60,8 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, assertEqual, testCase, testCaseSteps, (@?=))
 import Text.Printf (printf)
 import UnitTests.NullaryConstructors (nullaryConstructors)
+import UnitTests.OptionalFields (optionalFields)
+import qualified Data.ByteString as S
 import qualified Data.ByteString.Base16.Lazy as LBase16
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Text.Lazy as LT
@@ -804,6 +806,7 @@ tests = testGroup "unit" [
   , testGroup "Object construction" $ fmap (testCase "-") objectConstruction
   , testGroup "Issue #351" $ fmap (testCase "-") issue351
   , testGroup "Nullary constructors" $ fmap (testCase "-") nullaryConstructors
+  , testGroup "Optional fields" optionalFields
   , testGroup "FromJSONKey" $ fmap (testCase "-") fromJSONKeyAssertions
   , testCase "PR #455" pr455
   , testCase "Unescape string (PR #477)" unescapeString

--- a/tests/UnitTests/OptionalFields.hs
+++ b/tests/UnitTests/OptionalFields.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module UnitTests.OptionalFields (optionalFields) where
+
+import Data.Maybe (isNothing)
+import UnitTests.OptionalFields.Common
+import UnitTests.OptionalFields.Generics (omitGenerics)
+import UnitTests.OptionalFields.TH (omitTH)
+
+optionalFields :: [TestTree]
+optionalFields = [omitGenerics, omitTH, proofOfConcept]
+
+-- c.f. https://github.com/haskell/aeson/pull/839#issuecomment-782453()6()
+data P = P
+  { x :: Nullable Int -- Field is required, but can be null.
+  , y :: Undefineable Int -- Field is optional, but cannot be null.
+  , z :: NullOrUndefineable Int -- Field is optional, and can be null.
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON P where
+  toJSON = genericToJSON opts
+  toEncoding = genericToEncoding opts
+
+instance FromJSON P where
+  parseJSON = genericParseJSON opts
+
+newtype Nullable a = Nullable (Maybe a)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON a => ToJSON (Nullable a) where
+  toJSON = genericToJSON opts
+  toEncoding = genericToEncoding opts
+
+instance FromJSON a => FromJSON (Nullable a) where
+  parseJSON = genericParseJSON opts
+
+newtype Undefineable a = Undefineable (Maybe a)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON a => ToJSON (Undefineable a) where
+  toJSON = genericToJSON opts
+  toEncoding = genericToEncoding opts
+  omitField (Undefineable a) = isNothing a
+
+instance FromJSON a => FromJSON (Undefineable a) where
+  parseJSON Null = fail "Undefineable.parseJSON: expected non-null value"
+  parseJSON v = genericParseJSON opts v
+  omittedField = Just (Undefineable Nothing)
+
+newtype NullOrUndefineable a = NullOrUndefineable (Maybe a)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON a => ToJSON (NullOrUndefineable a) where
+  toJSON = genericToJSON opts
+  toEncoding = genericToEncoding opts
+  omitField (NullOrUndefineable a) = isNothing a
+
+instance FromJSON a => FromJSON (NullOrUndefineable a) where
+  parseJSON = genericParseJSON opts
+  omittedField = Just (NullOrUndefineable Nothing)
+
+opts :: Options
+opts = defaultOptions { omitNothingFields = True }
+
+fullP :: P
+fullP = P (Nullable $ Just 0) (Undefineable $ Just 0) (NullOrUndefineable $ Just 0)
+
+zero :: String -> (Key, Value)
+zero = flip prop (0 :: Int)
+
+proofOfConcept :: TestTree
+proofOfConcept = testGroup "Type-directed optional fields Proof of Concept"
+  [ testGroup "toJSON"
+    [ testCase "x is not omitted when Nothing" $
+        let subject = fullP {x = Nullable Nothing}
+            expected = obj [prop "x" Null, zero "y", zero "z"]
+         in toJSON subject @?= expected
+
+    , testCase "y is omitted when Nothing" $
+        let subject = fullP {y = Undefineable Nothing}
+            expected = obj [zero "x", zero "z"]
+         in toJSON subject @?= expected
+
+    , testCase "z is omitted when Nothing" $
+        let subject = fullP {z = NullOrUndefineable Nothing}
+            expected = obj [zero "x", zero "y"]
+         in toJSON subject @?= expected
+    ]
+
+  , testGroup "parseJSON"
+    [ testCase "x can be null" $
+        let subject = obj [prop "x" Null, zero "y", zero "z"]
+            expected = Just fullP {x = Nullable Nothing}
+         in decode (encode subject) @?= expected
+
+    , testCase "x cannot be omitted" $
+        let subject = obj [zero "y", zero "z"]
+            expected = Nothing :: Maybe P
+         in decode (encode subject) @?= expected
+
+    , testCase "y can be omitted" $
+        let subject = obj [zero "x", zero "z"]
+            expected = Just fullP {y = Undefineable Nothing}
+         in decode (encode subject) @?= expected
+
+    , testCase "y cannot be null" $
+        let subject = obj [zero "x", prop "y" Null, zero "z"]
+            expected = Nothing :: Maybe P
+         in decode (encode subject) @?= expected
+
+    , testCase "z can be null" $
+        let subject = obj [zero "x", zero "y", prop "z" Null]
+            expected = Just fullP {z = NullOrUndefineable Nothing}
+         in decode (encode subject) @?= expected
+
+    , testCase "z can be omitted" $
+        let subject = obj [zero "x", zero "y"]
+            expected = Just fullP {z = NullOrUndefineable Nothing}
+         in decode (encode subject) @?= expected
+    ]
+  ]

--- a/tests/UnitTests/OptionalFields/Common.hs
+++ b/tests/UnitTests/OptionalFields/Common.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module UnitTests.OptionalFields.Common
+  ( module UnitTests.OptionalFields.Common
+  , module Data.Aeson
+  , module Data.Aeson.TH
+  , module GHC.Generics
+  , module Test.Tasty
+  , module Test.Tasty.HUnit
+  ) where
+
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Maybe (isNothing)
+import Data.Semigroup (Semigroup (..))
+import GHC.Generics
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Text as T
+
+newtype NullableNonEmptyString = NullableNonEmptyString (Maybe String)
+  deriving (Eq, Ord, Show, Generic, Semigroup, Monoid)
+
+instance ToJSON NullableNonEmptyString where
+  toJSON (NullableNonEmptyString x) = toJSON x
+  omitField (NullableNonEmptyString x) = isNothing x
+
+instance FromJSON NullableNonEmptyString where
+  parseJSON Null = pure mempty
+  parseJSON (String x) = pure (nne $ T.unpack x)
+  parseJSON _ = fail "NullableNonEmptyString.parseJSON: expected String or Null"
+
+  omittedField = Just mempty
+
+nne :: String -> NullableNonEmptyString
+nne str = case filter (/= ' ') str of
+  "" -> NullableNonEmptyString Nothing
+  _ -> NullableNonEmptyString (Just str)
+
+obj :: [(Key, Value)] -> Value
+obj = Object . KM.fromList
+
+prop :: ToJSON a => String -> a -> (Key, Value)
+prop k v = (K.fromString k, toJSON v)
+
+data RecordA = RecordA
+  { required :: String
+  , optional :: NullableNonEmptyString
+  }
+  deriving Generic
+
+data RecordB = RecordB
+  { required :: String
+  , optional :: NullableNonEmptyString
+  }
+  deriving Generic
+
+encodeCase :: HasCallStack => ToJSON a => a -> Value -> IO ()
+encodeCase record object' = decode @Value (encode record) @?= Just object'
+
+decodeCase :: forall a. HasCallStack => (FromJSON a, ToJSON a) => a -> Value -> IO ()
+decodeCase record object' = (fmap encode . decode @a . encode) object' @?= Just (encode record)
+
+counterCase :: forall a proxy. HasCallStack => (FromJSON a, ToJSON a) => proxy a -> Value -> IO ()
+counterCase _ object' = assertBool "decode should fail" $ (null . decode @a . encode) object'
+
+helloWorldRecA :: RecordA
+helloWorldRecA = RecordA "hello" (nne "world")
+
+helloWorldRecB :: RecordB
+helloWorldRecB = RecordB "hello" (nne "world")
+
+helloWorldObj :: Value
+helloWorldObj = obj
+  [ prop "required" "hello"
+  , prop "optional" "world"
+  ]
+
+helloRecA :: RecordA
+helloRecA = RecordA "hello" mempty
+
+helloRecB :: RecordB
+helloRecB = RecordB "hello" mempty
+
+helloObj :: Value
+helloObj = obj
+  [ prop "required" "hello"
+  ]
+
+helloNullObj :: Value
+helloNullObj = obj
+  [ prop "required" "hello"
+  , prop "optional" Null
+  ]

--- a/tests/UnitTests/OptionalFields/Generics.hs
+++ b/tests/UnitTests/OptionalFields/Generics.hs
@@ -1,0 +1,23 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module UnitTests.OptionalFields.Generics (omitGenerics) where
+
+import UnitTests.OptionalFields.Common
+
+instance ToJSON RecordA where
+  toJSON = genericToJSON defaultOptions { omitNothingFields = True }
+
+instance ToJSON RecordB where
+  toJSON = genericToJSON defaultOptions { omitNothingFields = False }
+
+omitGenerics :: TestTree
+omitGenerics = testGroup "Omit optional fields (Generics)"
+  [ testGroup "omitNothingFields = True"
+    [ testCase "JSON should include non-optional value." $ encodeCase helloWorldRecA helloWorldObj
+    , testCase "JSON should not include optional value." $ encodeCase helloRecA helloObj
+    ]
+  , testGroup "omitNothingFields = False"
+    [ testCase "JSON should include non-optional value." $ encodeCase helloWorldRecB helloWorldObj
+    , testCase "JSON should include optional value." $ encodeCase helloRecB helloNullObj
+    ]
+  ]

--- a/tests/UnitTests/OptionalFields/TH.hs
+++ b/tests/UnitTests/OptionalFields/TH.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module UnitTests.OptionalFields.TH (omitTH) where
+
+import UnitTests.OptionalFields.Common
+
+$(deriveToJSON defaultOptions { omitNothingFields = True } ''RecordA)
+
+$(deriveToJSON defaultOptions { omitNothingFields = False } ''RecordB)
+
+omitTH :: TestTree
+omitTH = testGroup "Omit optional fields (TH)"
+  [ testGroup "omitNothingFields = True"
+    [ testCase "JSON should include non-optional value." $ encodeCase helloWorldRecA helloWorldObj
+    , testCase "JSON should not include optional value." $ encodeCase helloRecA helloObj
+    ]
+  , testGroup "omitNothingFields = False"
+    [ testCase "JSON should include non-optional value." $ encodeCase helloWorldRecB helloWorldObj
+    , testCase "JSON should include optional value." $ encodeCase helloRecB helloNullObj
+    ]
+  ]


### PR DESCRIPTION
This PR makes a backwards-compatible change to `ToJSON` and `FromJSON` that allows the instance to configure the optionality of record fields of that type when using Generic deriving or Template Haskell deriving.

Specifically, we make the following use-facing changes:

```haskell
class ToJSON a where
    ...
    omitField :: a -> Bool
    omitField _ = False
```

and

```haskell
class FromJSON a where
    ...
    omittedField :: Maybe a
    omittedField = Nothing
```

The new methods have default implementations that preserve the current behavior of Generically-derived and Template Haskell created instances.
Instance authors can use these methods to configure how to represent fields of this type as omitted from a JSON record.
As an added benefit, this PR eliminates the needs for special-case handling of `Maybe` and `Option`, significantly simplifying the Generic and Template Haskell code.

This PR solves https://github.com/haskell/aeson/issues/646 and https://github.com/haskell/aeson/issues/792, and it's similar to https://github.com/haskell/aeson/pull/839 by @phadej.
Please let me know what you think, if this PR is a suitable addition to Aeson, and if there's anything about it you'd like me to fix or change.

Thanks much!