### PR TITLE
Improve `Arbitrary Value` instance.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ For the latest version of this document, please see [https://github.com/haskell/
 * Remove `cffi` flag. Then the C implementation for string unescaping was used for `text <2` versions.
   The new native Haskell implementation introduced in version 2.0.3.0 is at least as fast.
 * Drop instances for `attoparsec.Number`.
+* Improve `Arbitrary Value` instance.
 
 ### 2.1.2.1
 

--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -439,11 +439,13 @@ type RepValue
 
 arbValue :: Int -> QC.Gen Value
 arbValue n
-    | n <= 0 = QC.oneof
+    | n <= 1 = QC.oneof
         [ pure Null
         , Bool <$> QC.arbitrary
         , String <$> arbText
         , Number <$> arbScientific
+        , pure emptyObject
+        , pure emptyArray
         ]
 
     | otherwise = QC.oneof


### PR DESCRIPTION
Fixes #980. As discussed there, simply changing `n <= 0` to `n <= 1` gives good generation of strings, bools, numbers and null. Turns out it also forbids `[]` and `{}` from being generated, so I added those explicitly to that case.

My understanding is this requires a major version bump, as a change in behavior of an exported function.

--

This is rebased #981, therefore closes #981.