### PR TITLE
Split some unit tests from UnitTests-megamodule

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -163,12 +163,18 @@ test-suite aeson-tests
     PropertyRTFunctors
     PropertyTH
     PropUtils
+    Regression.Issue351
     Regression.Issue571
     Regression.Issue967
     SerializationFormatSpec
     Types
     UnitTests
+    UnitTests.FromJSONKey
+    UnitTests.Hashable
+    UnitTests.KeyMapInsertWith
+    UnitTests.MonadFix
     UnitTests.NullaryConstructors
+    UnitTests.UTCTime
 
   build-depends:
       aeson

--- a/tests/Regression/Issue351.hs
+++ b/tests/Regression/Issue351.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Regression.Issue351 (issue351) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, assertEqual)
+import Data.Maybe (fromMaybe)
+
+import qualified Data.ByteString.Lazy as L
+
+import Data.Aeson
+
+-- A regression test for: https://github.com/bos/aeson/issues/351
+overlappingRegression :: FromJSON a => L.ByteString -> [a]
+overlappingRegression bs = fromMaybe [] $ decode bs
+
+issue351 :: TestTree
+issue351 = testGroup "Issue #351" $ map (testCase "-")
+  [ assertEqual "Int"  ([1, 2, 3] :: [Int])  $ overlappingRegression "[1, 2, 3]"
+  , assertEqual "Char" ("abc"     :: String) $ overlappingRegression "\"abc\""
+  , assertEqual "Char" (""        :: String) $ overlappingRegression "[\"a\", \"b\", \"c\"]"
+  ]

--- a/tests/UnitTests/FromJSONKey.hs
+++ b/tests/UnitTests/FromJSONKey.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module UnitTests.FromJSONKey (fromJSONKeyTests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, Assertion, assertFailure)
+import Data.Text (Text)
+import Data.Tagged (Tagged)
+import Control.Applicative (Const)
+
+import Data.Aeson
+
+newtype MyText = MyText Text
+    deriving (FromJSONKey)
+
+newtype MyText' = MyText' Text
+
+instance FromJSONKey MyText' where
+    fromJSONKey = fmap MyText' fromJSONKey
+    fromJSONKeyList = error "not used"
+
+fromJSONKeyTests :: TestTree
+fromJSONKeyTests = testGroup "FromJSONKey" $ fmap (testCase "-") fromJSONKeyAssertions
+
+fromJSONKeyAssertions :: [Assertion]
+fromJSONKeyAssertions =
+    [ assertIsCoerce  "Text"            (fromJSONKey :: FromJSONKeyFunction Text)
+    , assertIsCoerce  "Tagged Int Text" (fromJSONKey :: FromJSONKeyFunction (Tagged Int Text))
+    , assertIsCoerce  "MyText"          (fromJSONKey :: FromJSONKeyFunction MyText)
+
+    , assertIsCoerce' "MyText'"         (fromJSONKey :: FromJSONKeyFunction MyText')
+    , assertIsCoerce  "Const Text"      (fromJSONKey :: FromJSONKeyFunction (Const Text ()))
+    ]
+  where
+    assertIsCoerce :: String -> FromJSONKeyFunction a -> Assertion
+    assertIsCoerce _ FromJSONKeyCoerce = pure ()
+    assertIsCoerce n _                 = assertFailure n
+
+    assertIsCoerce' :: String -> FromJSONKeyFunction a -> Assertion
+    assertIsCoerce' _ FromJSONKeyCoerce = pure ()
+    assertIsCoerce' n _                 = pickWithRules (assertFailure n) (pure ())
+
+-- | Pick the first when RULES are enabled, e.g. optimisations are on
+pickWithRules
+    :: a -- ^ Pick this when RULES are on
+    -> a -- ^ use this otherwise
+    -> a
+pickWithRules _ = id
+{-# NOINLINE pickWithRules #-}
+{-# RULES "pickWithRules/rule" [0] forall x. pickWithRules x = const x #-}

--- a/tests/UnitTests/Hashable.hs
+++ b/tests/UnitTests/Hashable.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UnitTests.Hashable (hashableLaws) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, assertEqual)
+import Data.Hashable (hash)
+
+import Data.Aeson
+
+------------------------------------------------------------------------------
+-- Check that the hashes of two equal Value are the same
+------------------------------------------------------------------------------
+
+hashableLaws :: TestTree
+hashableLaws = testGroup "Hashable laws" $ fmap (testCase "-")
+  [ assertEqual "Hashable Object" (hash a) (hash b)
+  ]
+  where
+  a = object ["223" .= False, "807882556" .= True]
+  b = object ["807882556" .= True, "223" .= False]

--- a/tests/UnitTests/KeyMapInsertWith.hs
+++ b/tests/UnitTests/KeyMapInsertWith.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UnitTests.KeyMapInsertWith (keyMapInsertWithTests) where
+
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+import qualified Data.Aeson.KeyMap as KM
+
+keyMapInsertWithTests :: TestTree
+keyMapInsertWithTests = testCase "KeyMap.insertWith" $ do
+  KM.insertWith (-)        "a" 2 (KM.fromList [("a", 1)]) @?= KM.fromList [("a",1 :: Int)]
+  KM.insertWith (flip (-)) "a" 2 (KM.fromList [("a", 1)]) @?= KM.fromList [("a",-1 :: Int)]
+  KM.insertWith (-)        "b" 2 (KM.fromList [("a", 1)]) @?= KM.fromList [("a",1),("b",2 :: Int)]
+  KM.insertWith (-)        "b" 2 KM.empty                 @?= KM.fromList [("b",2 :: Int)]

--- a/tests/UnitTests/MonadFix.hs
+++ b/tests/UnitTests/MonadFix.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecursiveDo #-}
+module UnitTests.MonadFix (monadFixTests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, Assertion, (@?=))
+
+import qualified Data.Map as Map -- Lazy
+
+import Data.Aeson
+import Data.Aeson.Types
+import qualified Data.Aeson.KeyMap as KM
+
+-------------------------------------------------------------------------------
+-- MonadFix
+-------------------------------------------------------------------------------
+
+monadFixDecoding1 :: (Value -> Data.Aeson.Types.Parser [Char]) -> Assertion
+monadFixDecoding1 p = do
+    fmap (take 10) (parseMaybe p value) @?= Just "xyzxyzxyzx"
+  where
+    value = object
+        [ "foo" .= ('x', "bar" :: String)
+        , "bar" .= ('y', "quu" :: String)
+        , "quu" .= ('z', "foo" :: String)
+        ]
+
+monadFixDecoding2 :: (Value -> Data.Aeson.Types.Parser [Char]) -> Assertion
+monadFixDecoding2 p = do
+    fmap (take 10) (parseMaybe p value) @?= Nothing
+  where
+    value = object
+        [ "foo" .= ('x', "bar" :: String)
+        , "bar" .= ('y', "???" :: String)
+        , "quu" .= ('z', "foo" :: String)
+        ]
+
+monadFixDecoding3 :: (Value -> Data.Aeson.Types.Parser [Char]) -> Assertion
+monadFixDecoding3 p =
+    fmap (take 10) (parseMaybe p value) @?= Nothing
+  where
+    value = object
+        [ "foo" .= ('x', "bar" :: String)
+        , "bar" .= Null
+        , "quu" .= ('z', "foo" :: String)
+        ]
+
+monadFixDecoding4 :: (Value -> Data.Aeson.Types.Parser [Char]) -> Assertion
+monadFixDecoding4 p =
+    fmap (take 10) (parseMaybe p value) @?= Nothing
+  where
+    value = object
+        [ "els" .= ('x', "bar" :: String)
+        , "bar" .= Null
+        , "quu" .= ('z', "foo" :: String)
+        ]
+
+-- Parser with explicit references
+monadFixParserA :: Value -> Data.Aeson.Types.Parser [Char]
+monadFixParserA = withObject "Rec" $ \obj -> mdo
+    let p'' :: Value -> Data.Aeson.Types.Parser String
+        p'' "foo" = return foo
+        p'' "bar" = return bar
+        p'' "quu" = return quu
+        p'' _     = fail "Invalid reference"
+
+    let p' :: Value -> Data.Aeson.Types.Parser [Char]
+        p' v = do
+            (c, cs) <- liftParseJSON p'' (listParser p'') v
+            return (c : cs)
+
+    foo <- explicitParseField p' obj "foo"
+    bar <- explicitParseField p' obj "bar"
+    quu <- explicitParseField p' obj "quu"
+    return foo
+
+-- Parser with arbitrary references!
+monadFixParserB :: Value -> Data.Aeson.Types.Parser [Char]
+monadFixParserB = withObject "Rec" $ \obj -> mdo
+    let p'' :: Value -> Data.Aeson.Types.Parser String
+        p'' key' = do
+            key <- parseJSON key'
+            -- this is ugly: we look whether key is in original obj
+            -- but then query from refs.
+            --
+            -- This way we are lazier. Map.traverse isn't lazy enough.
+            case KM.lookup key obj of
+                Just _  -> return (refs Map.! key)
+                Nothing -> fail "Invalid reference"
+
+    let p' :: Value -> Data.Aeson.Types.Parser [Char]
+        p' v = do
+            (c, cs) <- liftParseJSON p'' (listParser p'') v
+            return (c : cs)
+
+    refs <- traverse p' (KM.toMap obj)
+    case Map.lookup "foo" refs of
+        Nothing   -> fail "No foo node"
+        Just root -> return root
+
+monadFixTests :: TestTree
+monadFixTests = testGroup "MonadFix"
+    [ testCase "Example1a" $ monadFixDecoding1 monadFixParserA
+    , testCase "Example2a" $ monadFixDecoding2 monadFixParserA
+    , testCase "Example3a" $ monadFixDecoding3 monadFixParserA
+    , testCase "Example4a" $ monadFixDecoding4 monadFixParserA
+
+    , testCase "Example1b" $ monadFixDecoding1 monadFixParserB
+    , testCase "Example2b" $ monadFixDecoding2 monadFixParserB
+    , testCase "Example3b" $ monadFixDecoding3 monadFixParserB
+    , testCase "Example4b" $ monadFixDecoding4 monadFixParserB
+    ]

--- a/tests/UnitTests/UTCTime.hs
+++ b/tests/UnitTests/UTCTime.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UnitTests.UTCTime (utcTimeTests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, testCaseSteps, Assertion, assertEqual, assertFailure)
+import Data.Maybe (fromMaybe)
+import Data.Time (UTCTime, ZonedTime)
+import Data.Time.Format.Compat (parseTimeM, defaultTimeLocale)
+
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Encoding as LT
+
+import Data.Aeson
+
+-- Test decoding various UTC time formats
+utcTimeGood :: Assertion
+utcTimeGood = do
+  let ts1 = "2015-01-01T12:13:00.00Z"
+  let ts2 = "2015-01-01T12:13:00Z"
+  -- 'T' between date and time is not required, can be space
+  let ts3 = "2015-01-03 12:13:00.00Z"
+  let ts4 = "2015-01-03 12:13:00.125Z"
+  t1 <- parseWithAeson ts1
+  t2 <- parseWithAeson ts2
+  t3 <- parseWithAeson ts3
+  t4 <- parseWithAeson ts4
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" ts1) t1
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" ts2) t2
+  assertEqual "utctime" (parseWithRead "%F %T%QZ" ts3) t3
+  assertEqual "utctime" (parseWithRead "%F %T%QZ" ts4) t4
+  -- Time zones.  Both +HHMM and +HH:MM are allowed for timezone
+  -- offset, and MM may be omitted.
+  let ts5 = "2015-01-01T12:30:00.00+00"
+  let ts6 = "2015-01-01T12:30:00.00+01:15"
+  let ts7 = "2015-01-01T12:30:00.00-02"
+  let ts8 = "2015-01-01T22:00:00.00-03"
+  let ts9 = "2015-01-01T22:00:00.00-04:30"
+  t5 <- parseWithAeson ts5
+  t6 <- parseWithAeson ts6
+  t7 <- parseWithAeson ts7
+  t8 <- parseWithAeson ts8
+  t9 <- parseWithAeson ts9
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T12:30:00.00Z") t5
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T11:15:00.00Z") t6
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T14:30:00Z") t7
+  -- ts8 wraps around to the next day in UTC
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T01:00:00Z") t8
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T02:30:00Z") t9
+
+  -- Seconds in Time can be omitted
+  let ts10 = "2015-01-03T12:13Z"
+  let ts11 = "2015-01-03 12:13Z"
+  let ts12 = "2015-01-01T12:30-02"
+  t10 <- parseWithAeson ts10
+  t11 <- parseWithAeson ts11
+  t12 <- parseWithAeson ts12
+  assertEqual "utctime" (parseWithRead "%FT%H:%MZ" ts10) t10
+  assertEqual "utctime" (parseWithRead "%F %H:%MZ" ts11) t11
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T14:30:00Z") t12
+
+  -- leap seconds are included correctly
+  let ts13 = "2015-08-23T23:59:60.128+00"
+  t13 <- parseWithAeson ts13
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-08-23T23:59:60.128Z") t13
+  let ts14 = "2015-08-23T23:59:60.999999999999+00"
+  t14 <- parseWithAeson ts14
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-08-23T23:59:60.999999999999Z") t14
+
+  where
+    parseWithRead :: String -> LT.Text -> UTCTime
+    parseWithRead f s =
+      fromMaybe (error "parseTime input malformed") . parseTimeM True defaultTimeLocale f . LT.unpack $ s
+
+    parseWithAeson :: LT.Text -> IO UTCTime
+    parseWithAeson s = either fail return . eitherDecode . LT.encodeUtf8 $ LT.concat ["\"", s, "\""]
+
+-- Test that a few non-timezone qualified timestamp formats get
+-- rejected if decoding to UTCTime.
+utcTimeBad :: (String -> IO ()) -> Assertion
+utcTimeBad info = do
+  verifyFailParse "2000-01-01T12:13:00" -- missing Zulu time not allowed (some TZ required)
+  verifyFailParse "2000-01-01 12:13:00" -- missing Zulu time not allowed (some TZ required)
+  verifyFailParse "2000-01-01"          -- date only not OK
+  verifyFailParse "2000-01-01Z"         -- date only not OK
+  verifyFailParse "2015-01-01T12:30:00.00+00Z" -- no Zulu if offset given
+  verifyFailParse "2015-01-01T12:30:00.00+00:00Z" -- no Zulu if offset given
+  verifyFailParse "2015-01-03 12:13:00.Z" -- decimal at the end but no digits
+  verifyFailParse "2015-01-03 12:13.000Z" -- decimal at the end, but no seconds
+  verifyFailParse "2015-01-03 23:59:61Z"  -- exceeds allowed seconds per day
+  verifyFailParse "2015-01-03 12:13:00 Z" -- space before Zulu
+  verifyFailParse "2015-01-03 12:13:00 +00:00" -- space before offset
+  where
+    verifyFailParse :: LT.Text -> Assertion
+    verifyFailParse s = do
+      info (LT.unpack s)
+      let bs = LT.encodeUtf8 $ LT.concat ["\"", s, "\""]
+      let decU = decode bs :: Maybe UTCTime
+      let decZ = decode bs :: Maybe ZonedTime
+      assertIsNothing "verify failure UTCTime"   decU
+      assertIsNothing "verify failure ZonedTime"   decZ
+
+assertIsNothing :: Show a => String -> Maybe a -> Assertion
+assertIsNothing _    Nothing = return ()
+assertIsNothing err (Just a) = assertFailure $ err ++ " " ++ show a
+
+utcTimeTests :: TestTree
+utcTimeTests = testGroup "utctime" [
+      testCase "good" utcTimeGood
+    , testCaseSteps "bad"  utcTimeBad
+    ]


### PR DESCRIPTION
This helps with recompilation speed while developing, as well as with finding the tests.