### PR TITLE
Produce Value in normal form in D.A.Decoding.

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -183,11 +183,13 @@ test-suite aeson-tests
     UnitTests.OptionalFields.Manual
     UnitTests.OptionalFields.TH
     UnitTests.UTCTime
+    UnitTests.NoThunks
 
   build-depends:
       aeson
     , base
     , base-compat
+    , deepseq
     , base-orphans          >=0.5.3  && <0.10
     , base16-bytestring
     , bytestring
@@ -224,6 +226,9 @@ test-suite aeson-tests
     , unordered-containers
     , uuid-types
     , vector
+
+  if impl(ghc >=9.2 && <9.7)
+    build-depends: nothunks >=0.1.4 && <0.2
 
 source-repository head
   type:     git

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -26,7 +26,7 @@ library
   default-language: Haskell2010
   build-depends:    base
 
-executable aeson-benchmark-suite
+executable aeson-bench
   default-language: Haskell2010
   main-is:          aeson-benchmark-suite.hs
   hs-source-dirs:   bench examples/src

--- a/benchmarks/bench/CompareWithJSON.hs
+++ b/benchmarks/bench/CompareWithJSON.hs
@@ -47,11 +47,26 @@ decode' :: BL.ByteString -> A.Value
 decode' s = fromMaybe (error "fail to parse via Aeson") $ A.decode' s
 
 decodeS :: BS.ByteString -> A.Value
-decodeS s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict' s
+decodeS s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict s
+
+decodeS' :: BS.ByteString -> A.Value
+decodeS' s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict' s
 
 decodeAtto :: BL.ByteString -> A.Value
 decodeAtto s = fromMaybe (error "fail to parse via Parser.decodeWith") $
     I.decodeWith I.jsonEOF A.fromJSON s
+
+decodeAtto' :: BL.ByteString -> A.Value
+decodeAtto' s = fromMaybe (error "fail to parse via Parser.decodeWith") $
+    I.decodeWith I.jsonEOF' A.fromJSON s
+
+decodeAttoS :: BS.ByteString -> A.Value
+decodeAttoS s = fromMaybe (error "fail to parse via Parser.decodeWith") $
+    I.decodeStrictWith I.jsonEOF A.fromJSON s
+
+decodeAttoS' :: BS.ByteString -> A.Value
+decodeAttoS' s = fromMaybe (error "fail to parse via Parser.decodeWith") $
+    I.decodeStrictWith I.jsonEOF' A.fromJSON s
 
 encodeJ :: J.JSValue -> BL.ByteString
 encodeJ = toLazyByteString . fromString . J.encode
@@ -72,17 +87,43 @@ benchmark =
   env (readStr jpFile) $ \jpJ ->
   bgroup "compare-json" [
       bgroup "decode" [
-        bgroup "en" [
-          bench "aeson/lazy"       $ nf decode enA
-        , bench "aeson/strict"     $ nf decode' enA
-        , bench "aeson/stricter"   $ nf decodeS enS
-        , bench "aeson/attoparsec" $ nf decodeAtto enA
-        , bench "json"             $ nf decodeJ enJ
+        bgroup "whnf" [
+          -- Note: we use whnf to only force the outer constructor,
+          -- which may force different amount of value substructure.
+          bench "aeson/normal"      $ whnf decode enA
+        , bench "aeson/normal'"     $ whnf decode' enA
+        , bench "aeson/strict"      $ whnf decodeS enS
+        , bench "aeson/strict'"     $ whnf decodeS' enS
+
+          -- attoparsec-aeson package
+        , bench "aeson/atto"        $ whnf decodeAtto enA
+        , bench "aeson/atto'"       $ whnf decodeAtto' enA
+        , bench "aeson/attoS"       $ whnf decodeAttoS enS
+        , bench "aeson/attoS'"      $ whnf decodeAttoS' enS
+
+          -- json package
+        , bench "json"              $ whnf decodeJ enJ
+        ]
+
+      , bgroup "nf" [
+          bench "aeson/normal"      $ nf decode enA
+        , bench "aeson/normal"      $ nf decode' enA
+        , bench "aeson/strict"      $ nf decodeS enS
+        , bench "aeson/strict'"     $ nf decodeS' enS
+
+          -- attoparsec-aeson package
+        , bench "aeson/atto"        $ nf decodeAtto enA
+        , bench "aeson/atto'"       $ nf decodeAtto' enA
+        , bench "aeson/attoS"       $ nf decodeAttoS enS
+        , bench "aeson/attoS'"      $ nf decodeAttoS' enS
+
+          -- json package
+        , bench "json"              $ nf decodeJ enJ
         ]
       , bgroup "jp" [
-          bench "aeson"          $ nf decode jpA
-        , bench "aeson/stricter" $ nf decodeS jpS
-        , bench "json"           $ nf decodeJ jpJ
+          bench "aeson/normal"      $ whnf decode jpA
+        , bench "aeson/strict"      $ whnf decodeS jpS
+        , bench "json"              $ whnf decodeJ jpJ
         ]
       ]
     , bgroup "encode" [

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,11 @@ For the latest version of this document, please see [https://github.com/haskell/
     [#792](https://github.com/haskell/aeson/issues/792).
 
 * Use `Data.Aeson.Decoding` parsing functions (introduced in version 2.1.2.0) as default in `Data.Aeson`.
+  As one side-effect, `decode` and `decode'` etc pair functions are operationally the same.
+  All variants use an intermediate `Value` in normal form.
+
+  The lazier variant could had `Value` thunks inside `Array` (i.e. `Vector`), but the record had been value strict since version `0.4.0.0` (before that the lazy `Data.Map` was used as `Object`).
+
 * Move `Data.Aeson.Parser` module into separate [`attoparsec-aeson`](https://hackage.haskell.org/package/attoparsec-aeson) package, as these parsers are not used by `aeson` itself anymore.
 * Use [`text-iso8601`](https://hackage.haskell.org/package/text-iso8601) package for parsing `time` types. These are slightly faster than previously used (copy of) `attoparsec-iso8601`.
 * Remove `cffi` flag. Toggling the flag made `aeson` use a C implementation for string unescaping (used for `text <2` versions).

--- a/src/Data/Aeson.hs
+++ b/src/Data/Aeson.hs
@@ -221,6 +221,8 @@ decodeStrict' = decodeStrict
 -- If this fails due to incomplete or invalid input, 'Nothing' is
 -- returned.
 --
+-- Since @2.2.0.0@ an alias for 'decodeFileStrict'.
+--
 decodeFileStrict' :: (FromJSON a) => FilePath -> IO (Maybe a)
 decodeFileStrict' = decodeFileStrict
 
@@ -231,21 +233,29 @@ eitherDecodeFileStrict =
 {-# INLINE eitherDecodeFileStrict #-}
 
 -- | Like 'decode'' but returns an error message when decoding fails.
+--
+-- Since @2.2.0.0@ an alias for 'eitherDecode'.
 eitherDecode' :: (FromJSON a) => L.ByteString -> Either String a
 eitherDecode' = eitherDecode
 {-# INLINE eitherDecode' #-}
 
 -- | Like 'decodeStrict'' but returns an error message when decoding fails.
+--
+-- Since @2.2.0.0@ an alias for 'eitherDecodeStrict'.
 eitherDecodeStrict' :: (FromJSON a) => B.ByteString -> Either String a
 eitherDecodeStrict' = eitherDecodeStrict
 {-# INLINE eitherDecodeStrict' #-}
 
 -- | Like 'decodeFileStrict'' but returns an error message when decoding fails.
+--
+-- Since @2.2.0.0@ an alias for 'eitherDecodeFileStrict''.
 eitherDecodeFileStrict' :: (FromJSON a) => FilePath -> IO (Either String a)
 eitherDecodeFileStrict' = eitherDecodeFileStrict
 {-# INLINE eitherDecodeFileStrict' #-}
 
 -- | Like 'decode'' but throws an 'AesonException' when decoding fails.
+--
+-- Since @2.2.0.0@ an alias for 'throwDecode'.
 --
 -- @since 2.1.2.0
 --
@@ -254,6 +264,8 @@ throwDecode' = throwDecode
 {-# INLINE throwDecode' #-}
 
 -- | Like 'decodeStrict'' but throws an 'AesonException' when decoding fails.
+--
+-- Since @2.2.0.0@ an alias for 'throwDecodeStrict'.
 --
 -- @since 2.1.2.0
 --

--- a/src/Data/Aeson/Decoding.hs
+++ b/src/Data/Aeson/Decoding.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Convertion to and from @aeson@ 'A.Value'.
+-- 
 module Data.Aeson.Decoding (
     decode,
     eitherDecode,

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -69,6 +69,7 @@ import UnitTests.FromJSONKey
 import UnitTests.Hashable
 import UnitTests.KeyMapInsertWith
 import UnitTests.MonadFix
+import UnitTests.NoThunks
 import UnitTests.NullaryConstructors (nullaryConstructors)
 import UnitTests.OptionalFields (optionalFields)
 import UnitTests.UTCTime
@@ -569,4 +570,5 @@ tests = testGroup "unit" [
   , issue967
   , keyMapInsertWithTests
   , omitNothingFieldsNoteTests
+  , noThunksTests
   ]

--- a/tests/UnitTests/NoThunks.hs
+++ b/tests/UnitTests/NoThunks.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module UnitTests.NoThunks where
+
+import           Test.Tasty            (TestTree, testGroup)
+
+#if __GLASGOW_HASKELL__ >=902 && __GLASGOW_HASKELL__ <907
+
+import           Data.Maybe            (isNothing)
+import           NoThunks.Class        (NoThunks (..), allNoThunks, noThunksInKeysAndValues)
+import           Test.QuickCheck       (ioProperty)
+import           Test.Tasty.HUnit      (assertFailure, testCase)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import qualified Data.Aeson.Key        as K
+import qualified Data.Aeson.KeyMap     as KM
+import qualified Data.Scientific       as Sci
+
+import           Data.Aeson
+
+noThunksTests :: TestTree
+noThunksTests = testGroup "nothunks"
+    [ testNoThunks "example1" "null"
+    , testNoThunks "example2" "[ 1, 2, 3, true ]"
+    , testNoThunks "example3" "{ \"1\": 1, \"2\": 2 }"
+    , testProperty "property" $ \input -> ioProperty $ do
+        let lbs = encode (input :: Value)
+        !value <- either fail return $ eitherDecode lbs
+        isNothing <$> noThunks [] (value :: Value)
+    ]
+  where
+    testNoThunks name bs = testCase name $ do
+        !value <- either fail return $ eitherDecode bs
+        x <- noThunks [] (value :: Value)
+        case x of
+            Nothing -> return ()
+            Just ti -> assertFailure $ show ti
+
+instance NoThunks Value
+
+instance NoThunks v => NoThunks (KM.KeyMap v) where
+    wNoThunks ctx m = noThunksInKeysAndValues ctx (KM.toList m)
+    showTypeOf _ = "KeyMap"
+
+instance NoThunks K.Key where
+    wNoThunks _ _ = return Nothing
+    showTypeOf _ = "Key"
+
+instance NoThunks Sci.Scientific where
+    wNoThunks ctx s = do
+        let !c = Sci.coefficient s
+        let !e = Sci.base10Exponent s
+        allNoThunks [ wNoThunks ctx c, wNoThunks ctx e ]
+    showTypeOf _ = "Scientific"
+
+#else
+
+-- for other GHCs the test group is empty
+noThunksTests :: TestTree
+noThunksTests = testGroup "nothunks" []
+
+#endif


### PR DESCRIPTION
Add `nothunks` tests.
Previously thunks could hide inside `Array` (i.e. `Vector`); not anymore.

Resolves #315