### PR TITLE
Show everything builds `text-2.1` and `containers-0.7`

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -92,12 +92,12 @@ library
   build-depends:
       base              >=4.10.0.0 && <5
     , bytestring        >=0.10.8.2 && <0.12
-    , containers        >=0.5.10.2 && <0.7
+    , containers        >=0.5.10.2 && <0.8
     , deepseq           >=1.4.3.0  && <1.5
     , exceptions        >=0.10.4   && <0.11
     , ghc-prim          >=0.5.0.0  && <0.11
     , template-haskell  >=2.12.0.0 && <2.21
-    , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.1
+    , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
     , time              >=1.8.0.2  && <1.13
 
   -- Compat


### PR DESCRIPTION
Just making this PR to run the CI. If that is all green, this PR should be proof `aeson-2.2.0.0` can be revised to allow `text-2.1` and `containers-0.7`