### PR TITLE
Handle Functor Composition in Generic Instances

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -1452,6 +1452,13 @@ instance {-# OVERLAPPING #-}
       recordParseJSONImpl (guard (allowOmittedFields opts) >> fmap Par1 o) gParseJSON args obj
     {-# INLINE recordParseJSON' #-}
 
+instance {-# OVERLAPPING #-}
+         (Selector s, GFromJSON One (f :.: Rec1 g), FromJSON1 f, FromJSON1 g) =>
+         RecordFromJSON' One (S1 s (f :.: Rec1 g)) where
+    recordParseJSON' args@(_ :* _ :* opts :* From1Args o _ _) obj = recordParseJSONImpl d gParseJSON args obj where
+      d = guard (allowOmittedFields opts) >> fmap Comp1 (liftOmittedField (fmap Rec1 (liftOmittedField o)))
+    {-# INLINE recordParseJSON' #-}
+
 
 recordParseJSONImpl :: forall s arity a f i
                      . (Selector s)

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -1216,6 +1216,24 @@ instance ( Selector s
           in key `pair` value
     {-# INLINE recordToPairs #-}
 
+instance ( Selector s
+         , GToJSON' enc One (f :.: Rec1 g)
+         , KeyValuePair enc pairs
+         , ToJSON1 f
+         , ToJSON1 g
+         ) => RecordToPairs enc pairs One (S1 s (f :.: Rec1 g))
+  where
+    recordToPairs opts targs@(To1Args o _ _) m1
+      | omitNothingFields opts
+      , liftOmitField (liftOmitField o . unRec1) $ unComp1 $ unM1 m1
+      = mempty
+
+      | otherwise =
+        let key   = Key.fromString $ fieldLabelModifier opts (selName m1)
+            value = gToJSON opts targs (unM1 m1)
+            in key `pair` value
+    {-# INLINE recordToPairs #-}
+
 --------------------------------------------------------------------------------
 
 class WriteProduct arity f where


### PR DESCRIPTION
This fixes all cases of #1059 that are known to me.

The changes are minimally-invasive with regard to the existing setup. However, they only allow the pattern `f :.: Rec1 g` for composition. I do not know if this covers all the cases that can arise with `DeriveGeneric` or if there is maybe a more clever way to set things up (see https://github.com/haskell/aeson/issues/1059#issuecomment-1675966700).

I am submitting this as a draft pull request since I still need to check some things and add regression tests. Since I barely understand the existing infrastructure, I would be grateful for early feedback on whether the proposed implementation is on the right track.

Once completed, I would only want this to be merged after someone more knowledgeable takes a critical look at it.

Tasks:
- [x] add missing instances
- [ ] check if optional fields are handled correctly
- [ ] add regression test