### PR TITLE
Use GND to derive Key instances

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,7 +1,6 @@
 cabal-version:      2.2
 name:               aeson
-version:            2.2.2.0
-x-revision:         1
+version:            2.2.3.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Text, Web, JSON
@@ -116,7 +115,7 @@ library
     , character-ps          ^>=0.1
     , data-fix              ^>=0.3.2
     , dlist                 ^>=1.0
-    , hashable              ^>=1.4.2.0
+    , hashable              ^>=1.4.6.0
     , indexed-traversable   ^>=0.1.2
     , integer-conversion    ^>=0.1
     , integer-logarithms    ^>=1.0.3.1

--- a/cabal.project
+++ b/cabal.project
@@ -12,3 +12,5 @@ allow-newer: hermes-json:attoparsec-iso8601
 
 -- packages: https://hackage.haskell.org/package/libperf-0.1/candidate/libperf-0.1.tar.gz
 -- packages: https://hackage.haskell.org/package/tasty-perfbench-0.1/candidate/tasty-perfbench-0.1.tar.gz
+
+-- constraints: aeson -ordered-keymap

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 For the latest version of this document, please see [https://github.com/haskell/aeson/blob/master/changelog.md](https://github.com/haskell/aeson/blob/master/changelog.md).
 
+### 2.2.3.0
+
+* Support `hashable-1.4.6.0`.
+
 ### 2.2.2.0
 
 * Support GHC-8.6.5...9.10.1

--- a/src/Data/Aeson/Key.hs
+++ b/src/Data/Aeson/Key.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 -- |
@@ -39,7 +42,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 import qualified Test.QuickCheck as QC
 
 newtype Key = Key { unKey :: Text }
-  deriving (Eq, Ord, Typeable, Data)
+  deriving (Typeable, Data)
 
 fromString :: String -> Key
 fromString = Key . T.pack
@@ -58,7 +61,7 @@ toText = unKey
 --
 -- Using 'coercing' we can make more efficient implementations
 -- when 'Key' is backed up by 'Text' without exposing internals.
--- 
+--
 coercionToText :: Maybe (Coercion Key Text)
 coercionToText = Just Coercion
 {-# INLINE coercionToText #-}
@@ -79,13 +82,14 @@ instance Read Key where
     readPrec = fromString <$> readPrec
 
 instance Show Key where
-    showsPrec d (Key k) = showsPrec d k 
+    showsPrec d (Key k) = showsPrec d k
 
 instance Data.String.IsString Key where
     fromString = fromString
 
-instance Hashable Key where
-    hashWithSalt salt (Key k) = hashWithSalt salt k
+deriving newtype instance Eq Key
+deriving newtype instance Ord Key
+deriving newtype instance Hashable Key
 
 instance NFData Key where
     rnf (Key k) = rnf k


### PR DESCRIPTION
this fixes issue with `-fordered-keymap` and `hashable-1.4.5.0` which changed `hash @Text`, and `Key` instance felt out of sync. Not good for unsafe stuff we do.