### PR TITLE
Handle Functor Composition in Generic Instances

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -1013,29 +1013,17 @@ instance (FromJSON a) => GFromJSON arity (K1 i a) where
     gParseJSON _opts _ = fmap K1 . parseJSON
     {-# INLINE gParseJSON #-}
 
-instance FromJSON a => GOmitFromJSON arity (K1 i a) where
-    gOmittedField _ = fmap K1 omittedField
-    {-# INLINE gOmittedField #-}
-
 instance GFromJSON One Par1 where
     -- Direct occurrences of the last type parameter are decoded with the
     -- function passed in as an argument:
     gParseJSON _opts (From1Args _ pj _) = fmap Par1 . pj
     {-# INLINE gParseJSON #-}
 
-instance GOmitFromJSON One Par1 where
-    gOmittedField (From1Args o _ _) = fmap Par1 o
-    {-# INLINE gOmittedField #-}
-
 instance (FromJSON1 f) => GFromJSON One (Rec1 f) where
     -- Recursive occurrences of the last type parameter are decoded using their
     -- FromJSON1 instance:
     gParseJSON _opts (From1Args o pj pjl) = fmap Rec1 . liftParseJSON o pj pjl
     {-# INLINE gParseJSON #-}
-
-instance FromJSON1 f => GOmitFromJSON One (Rec1 f) where
-    gOmittedField (From1Args o _ _) = fmap Rec1 $ liftOmittedField o
-    {-# INLINE gOmittedField #-}
 
 instance (FromJSON1 f, GFromJSON One g) => GFromJSON One (f :.: g) where
     -- If an occurrence of the last type parameter is nested inside two
@@ -1048,6 +1036,18 @@ instance (FromJSON1 f, GFromJSON One g) => GFromJSON One (f :.: g) where
         let gpj = gParseJSON opts fargs
         in fmap Comp1 . liftParseJSON Nothing gpj (listParser gpj)
     {-# INLINE gParseJSON #-}
+
+instance FromJSON a => GOmitFromJSON arity (K1 i a) where
+    gOmittedField _ = fmap K1 omittedField
+    {-# INLINE gOmittedField #-}
+
+instance GOmitFromJSON One Par1 where
+    gOmittedField (From1Args o _ _) = fmap Par1 o
+    {-# INLINE gOmittedField #-}
+
+instance FromJSON1 f => GOmitFromJSON One (Rec1 f) where
+    gOmittedField (From1Args o _ _) = fmap Rec1 $ liftOmittedField o
+    {-# INLINE gOmittedField #-}
 
 instance (FromJSON1 f, GOmitFromJSON One g) => GOmitFromJSON One (f :.: g) where
     gOmittedField = fmap Comp1 . liftOmittedField . gOmittedField

--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -246,6 +246,9 @@ class GFromJSON arity f where
     -- or 'liftParseJSON' (if the @arity@ is 'One').
     gParseJSON :: Options -> FromArgs arity a -> Value -> Parser (f a)
 
+class GOmitFromJSON arity f where
+    gOmittedField :: FromArgs arity a -> Maybe (f a)
+
 -- | A 'FromArgs' value either stores nothing (for 'FromJSON') or it stores the
 -- three function arguments that decode occurrences of the type parameter (for
 -- 'FromJSON1').
@@ -1010,17 +1013,29 @@ instance (FromJSON a) => GFromJSON arity (K1 i a) where
     gParseJSON _opts _ = fmap K1 . parseJSON
     {-# INLINE gParseJSON #-}
 
+instance FromJSON a => GOmitFromJSON arity (K1 i a) where
+    gOmittedField _ = fmap K1 omittedField
+    {-# INLINE gOmittedField #-}
+
 instance GFromJSON One Par1 where
     -- Direct occurrences of the last type parameter are decoded with the
     -- function passed in as an argument:
     gParseJSON _opts (From1Args _ pj _) = fmap Par1 . pj
     {-# INLINE gParseJSON #-}
 
+instance GOmitFromJSON One Par1 where
+    gOmittedField (From1Args o _ _) = fmap Par1 o
+    {-# INLINE gOmittedField #-}
+
 instance (FromJSON1 f) => GFromJSON One (Rec1 f) where
     -- Recursive occurrences of the last type parameter are decoded using their
     -- FromJSON1 instance:
     gParseJSON _opts (From1Args o pj pjl) = fmap Rec1 . liftParseJSON o pj pjl
     {-# INLINE gParseJSON #-}
+
+instance FromJSON1 f => GOmitFromJSON One (Rec1 f) where
+    gOmittedField (From1Args o _ _) = fmap Rec1 $ liftOmittedField o
+    {-# INLINE gOmittedField #-}
 
 instance (FromJSON1 f, GFromJSON One g) => GFromJSON One (f :.: g) where
     -- If an occurrence of the last type parameter is nested inside two
@@ -1033,6 +1048,10 @@ instance (FromJSON1 f, GFromJSON One g) => GFromJSON One (f :.: g) where
         let gpj = gParseJSON opts fargs
         in fmap Comp1 . liftParseJSON Nothing gpj (listParser gpj)
     {-# INLINE gParseJSON #-}
+
+instance (FromJSON1 f, GOmitFromJSON One g) => GOmitFromJSON One (f :.: g) where
+    gOmittedField = fmap Comp1 . liftOmittedField . gOmittedField
+    {-# INLINE gOmittedField #-}
 
 --------------------------------------------------------------------------------
 
@@ -1420,36 +1439,9 @@ instance ( RecordFromJSON' arity a
               <*> recordParseJSON' p obj
     {-# INLINE recordParseJSON' #-}
 
-instance {-# OVERLAPPABLE #-}
-         RecordFromJSON' arity f => RecordFromJSON' arity (M1 i s f) where
-    recordParseJSON' args obj = M1 <$> recordParseJSON' args obj
-    {-# INLINE recordParseJSON' #-}
-
-instance (Selector s, FromJSON a, Generic a, K1 i a ~ Rep a) =>
-         RecordFromJSON' arity (S1 s (K1 i a)) where
-    recordParseJSON' args@(_ :* _ :* opts :* _) obj =
-      recordParseJSONImpl (guard (allowOmittedFields opts) >> fmap K1 omittedField) gParseJSON args obj
-    {-# INLINE recordParseJSON' #-}
-
-instance {-# OVERLAPPING #-}
-         (Selector s, FromJSON a) =>
-         RecordFromJSON' arity (S1 s (Rec0 a)) where
-    recordParseJSON' args@(_ :* _ :* opts :* _) obj =
-      recordParseJSONImpl (guard (allowOmittedFields opts) >> fmap K1 omittedField) gParseJSON args obj
-    {-# INLINE recordParseJSON' #-}
-
-instance {-# OVERLAPPING #-}
-         (Selector s, GFromJSON One (Rec1 f), FromJSON1 f) =>
-         RecordFromJSON' One (S1 s (Rec1 f)) where
-    recordParseJSON' args@(_ :* _ :* opts :* From1Args o _ _) obj =
-      recordParseJSONImpl (guard (allowOmittedFields opts) >> fmap Rec1 (liftOmittedField o)) gParseJSON args obj
-    {-# INLINE recordParseJSON' #-}
-
-instance {-# OVERLAPPING #-}
-         (Selector s, GFromJSON One Par1) =>
-         RecordFromJSON' One (S1 s Par1) where
-    recordParseJSON' args@(_ :* _ :* opts :* From1Args o _ _) obj =
-      recordParseJSONImpl (guard (allowOmittedFields opts) >> fmap Par1 o) gParseJSON args obj
+instance (Selector s, GFromJSON arity a, GOmitFromJSON arity a) => RecordFromJSON' arity (S1 s a) where
+    recordParseJSON' args@(_ :* _ :* opts :* fargs) obj =
+      recordParseJSONImpl (guard (allowOmittedFields opts) >> gOmittedField fargs) gParseJSON args obj
     {-# INLINE recordParseJSON' #-}
 
 

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -162,6 +162,9 @@ class GToJSON' enc arity f where
     -- and 'liftToEncoding' (if the @arity@ is 'One').
     gToJSON :: Options -> ToArgs enc arity a -> f a -> enc
 
+class GOmitToJSON enc arity f where
+    gOmitField :: ToArgs enc arity a -> f a -> Bool
+
 -- | A 'ToArgs' value either stores nothing (for 'ToJSON') or it stores the three
 -- function arguments that encode occurrences of the type parameter (for
 -- 'ToJSON1').
@@ -814,6 +817,22 @@ instance ( AllNullary       (a :+: b) allNullary
                        . sumToJSON opts targs
     {-# INLINE gToJSON #-}
 
+instance ToJSON a => GOmitToJSON enc arity (K1 i a) where
+    gOmitField _ = omitField . unK1
+    {-# INLINE gOmitField #-}
+
+instance GOmitToJSON enc One Par1 where
+    gOmitField (To1Args o _ _) = o . unPar1
+    {-# INLINE gOmitField #-}
+
+instance ToJSON1 f => GOmitToJSON enc One (Rec1 f) where
+    gOmitField (To1Args o _ _) = liftOmitField o . unRec1
+    {-# INLINE gOmitField #-}
+
+instance (ToJSON1 f, GOmitToJSON enc One g) => GOmitToJSON enc One (f :.: g) where
+    gOmitField targs = liftOmitField (gOmitField targs) . unComp1
+    {-# INLINE gOmitField #-}
+
 --------------------------------------------------------------------------------
 -- Generic toJSON
 
@@ -1167,47 +1186,14 @@ instance ( Monoid pairs
     {-# INLINE recordToPairs #-}
 
 instance ( Selector s
-         , GToJSON' enc arity (K1 i t)
+         , GToJSON' enc arity a
+         , GOmitToJSON enc arity a
          , KeyValuePair enc pairs
-         , ToJSON t
-         ) => RecordToPairs enc pairs arity (S1 s (K1 i t))
+         ) => RecordToPairs enc pairs arity (S1 s a)
   where
     recordToPairs opts targs m1
       | omitNothingFields opts
-      , omitField (unK1 $ unM1 m1 :: t)
-      = mempty
-
-      | otherwise =
-        let key   = Key.fromString $ fieldLabelModifier opts (selName m1)
-            value = gToJSON opts targs (unM1 m1)
-         in key `pair` value
-    {-# INLINE recordToPairs #-}
-
-instance ( Selector s
-         , GToJSON' enc One (Rec1 f)
-         , KeyValuePair enc pairs
-         , ToJSON1 f
-         ) => RecordToPairs enc pairs One (S1 s (Rec1 f))
-  where
-    recordToPairs opts targs@(To1Args o _ _) m1
-      | omitNothingFields opts
-      , liftOmitField o $ unRec1 $ unM1 m1
-      = mempty
-
-      | otherwise =
-        let key   = Key.fromString $ fieldLabelModifier opts (selName m1)
-            value = gToJSON opts targs (unM1 m1)
-            in key `pair` value
-    {-# INLINE recordToPairs #-}
-
-instance ( Selector s
-         , GToJSON' enc One Par1
-         , KeyValuePair enc pairs
-         ) => RecordToPairs enc pairs One (S1 s Par1)
-  where
-    recordToPairs opts targs@(To1Args o _ _) m1
-      | omitNothingFields opts
-      , o (unPar1 (unM1 m1))
+      , gOmitField targs $ unM1 m1
       = mempty
 
       | otherwise =


### PR DESCRIPTION
Second attempt at fixing #1059 after #1103 did not cover all cases. First discussion of the approach in https://github.com/haskell/aeson/issues/1059#issuecomment-2158531440.

Tasks:
- [x] add `GOmitFromJSON` and `GOmitToJSON` type classes and instances
- [x] replace `S1 s *` instances with single generic implementation based on `GOmitFromJSON` and `GOmitToJSON`
- [ ] investigate field omission propagation in existing instances `GFromJSON a (f :.: g)` and `GToJSON' e a (f :.: g)`
- [ ] inline `recordParseJSONImpl` that now has just a single call site
- [ ] add regression tests

I would be grateful for feedback by people more knowledgeable about the existing infrastructure than me.