### PR TITLE
fix doc reference in Data.Aeson.Decoding.Text

### DIFF
--- a/src/Data/Aeson/Decoding/Text.hs
+++ b/src/Data/Aeson/Decoding/Text.hs
@@ -36,7 +36,7 @@ type Point = Word16
 #endif
 
 
--- | Lex (and parse) strict 'ByteString' into 'Tokens' stream.
+-- | Lex (and parse) strict 'Text' into 'Tokens' stream.
 --
 -- @since 2.2.1.0
 --


### PR DESCRIPTION
A simple doc fix. I don't think a separate version bump or changelog entry is needed, best release this with any next version.