### PR TITLE
Rework TH instances context

### DIFF
--- a/tests/DataFamilies/Instances.hs
+++ b/tests/DataFamilies/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}


### PR DESCRIPTION
Instead of deriving instances for all datatype variables iterate over constructors generating instances based on how variables are used. Does the right thing in cases like
*  Phantom type variables
  Does not add corresponding instance to the context for unused variables
*  Type families
  Instead of generating `(ToJSON a)` for `data Foo a = Foo (SomeTypeFamily a)` generates `ToJSON (SomeTypeFamily a)`

Note that it slightly changes the behavior in cases like
``` haskell
data Foo a = Foo a deriving (ToJSON)

data Bar a = Bar (Foo a)
deriveToJSON defaultOptions ''Bar
```
will result in `ToJSON (Foo a)` constraint rather than `ToJSON a` (current behavior). I believe the former is more precise as that is exactly what generated encoder wants. The small downside is requirement for FlexibleContext extension.

TODO and open questions:
* [ ] How to test TH?
  Are there any helpers to get easy access to instance context. I think it would be nice to have something like
``` haskell
$(getContext $ deriveToJSON ...) `shouldBe` "ToJSON a, ToJSON b"
```
Can add if required. But maybe there are already established approach to test that. 
* [ ] Which test cases to add?
  I sketched up some cases, but that list is not exhaustive. And they should be reworked according to previous point 
* [ ] Should we test both From and To classes?
* [ ] Add Changelog